### PR TITLE
feat(portfolio): 포트폴리오 작성 기능 1차 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,17 @@
 			<version>2.20.0</version>
 		</dependency>
 		<dependency>
+			<groupId>com.github.downgoon</groupId>
+			<artifactId>marvin</artifactId>
+			<version>1.5.5</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>com.github.downgoon</groupId>
+			<artifactId>MarvinPlugins</artifactId>
+			<version>1.5.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -122,7 +133,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
 			<version>1.21.1</version>
 		</dependency>
 		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>2.20.26</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,16 @@
 			<version>2.20.26</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+			<version>3.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.20.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/io/github/sunday/devfolio/DTO/common/ImageUploadResult.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/common/ImageUploadResult.java
@@ -1,0 +1,41 @@
+package io.github.sunday.devfolio.dto.common;
+
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+/**
+ * AWS S3 이미지 업로드 결과 처리용 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ImageUploadResult {
+
+    /**
+     * 원본 파일 이름
+     */
+    private String originalFileName;
+
+    /**
+     * AWS S3 Key
+     */
+    private String s3Key;
+
+    /**
+     * 이미지 URL
+     */
+    private String imageUrl;
+
+    /**
+     * 파일 크기
+     */
+    private Long fileSize;
+
+    /**
+     * 업로드 날짜
+     */
+    private ZonedDateTime uploadedAt;
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/common/MultipartImage.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/common/MultipartImage.java
@@ -1,0 +1,43 @@
+package io.github.sunday.devfolio.dto.common;
+
+import lombok.*;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MultipartImage implements MultipartFile {
+    private byte[] bytes;
+    String name;
+    String originalFilename;
+    String contentType;
+    boolean isEmpty;
+    long size;
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public Resource getResource() {
+        return MultipartFile.super.getResource();
+    }
+
+    @Override
+    public void transferTo(Path dest) throws IOException, IllegalStateException {
+        MultipartFile.super.transferTo(dest);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioCommentDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioCommentDto.java
@@ -1,0 +1,52 @@
+package io.github.sunday.devfolio.dto.portfolio;
+
+import io.github.sunday.devfolio.dto.user.WriterDto;
+import lombok.*;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * 포트폴리오 댓글 응답 Dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioCommentDto {
+    /**
+     * 댓글의 고유 식별자 (기본키)
+     */
+    private Long commentIdx;
+
+    /**
+     * 댓글의 내용
+     */
+    private String content;
+
+    /**
+     * 댓글이 작성된 시점
+     */
+    private ZonedDateTime createdAt;
+
+    /**
+     * 댓글이 수정된 시점
+     */
+    private ZonedDateTime updatedAt;
+
+    /**
+     * 댓글을 작성한 사용자
+     */
+    private WriterDto writer;
+
+    /**
+     * 댓글이 속한 포트폴리오 식별자
+     */
+    private Long portfolioIdx;
+
+    /**
+     * 대댓글
+     */
+    private List<PortfolioCommentDto> subComments;
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioCommentRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioCommentRequestDto.java
@@ -1,0 +1,27 @@
+package io.github.sunday.devfolio.dto.portfolio;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 포트폴리오 댓글 작성 요청 Dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioCommentRequestDto {
+
+    /**
+     * 댓글이 속한 포트폴리오 식별자
+     */
+    @NotBlank(message = "포트폴리오 번호를 추가해주세요")
+    private Long portfolioIdx;
+
+    /**
+     * 댓글의 내용
+     */
+    @NotBlank(message = "댓글 내용을 입력해주세요")
+    private String content;
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioDetailDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioDetailDto.java
@@ -1,8 +1,95 @@
 package io.github.sunday.devfolio.dto.portfolio;
 
+import io.github.sunday.devfolio.dto.user.WriterDto;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
 /**
  * 포트폴리오의 상세 정보와 댓글을 제공하는 DTO
  * 포트폴리오의 전체 정보, 댓글, 통계, 작성자 정보
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class PortfolioDetailDto {
+
+    /**
+     * 포트폴리오의 고유 식별자 (기본키)
+     */
+    private Long portfolioIdx;
+
+    /**
+     * 포트폴리오 제목
+     */
+    private String title;
+
+    /**
+     * 프로젝트 시작일
+     */
+    private LocalDate startDate;
+
+    /**
+     * 프로젝트 종료일
+     */
+    private LocalDate endDate;
+
+    /**
+     * 포트폴리오 내용
+     */
+    private String description;
+
+    /**
+     * 포트폴리오 내용의 목차
+     */
+    private String descriptionIndex;
+
+    /**
+     * 포트폴리오 조회수
+     */
+    private Integer views;
+
+    /**
+     * 포트폴리오 좋아요 수
+     */
+    private Integer likeCount;
+
+    /**
+     * 댓글 수
+     */
+    private Integer commentCount;
+
+    /**
+     * 포트폴리오 생성일시
+     */
+    private ZonedDateTime createdAt;
+
+    /**
+     * 포트폴리오 수정일시
+     */
+    private ZonedDateTime updatedAt;
+
+    /**
+     * 포트폴리오 이미지
+     */
+    private List<PortfolioImageDto> images;
+
+    /**
+     * 작성자 정보
+     */
+    private WriterDto writer;
+
+    /**
+     * 포트폴리오 카테고리
+     */
+    private List<PortfolioCategoryDto> categories;
+
+    /**
+     * 댓글 목록
+     */
+    private List<PortfolioCommentDto> comments;
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioEditRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioEditRequestDto.java
@@ -3,5 +3,5 @@ package io.github.sunday.devfolio.dto.portfolio;
 /**
  * 포트폴리오 수정 요청 정보를 받는 DTO
  */
-public class PortfolioEditDto {
+public class PortfolioEditRequestDto {
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioImageDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioImageDto.java
@@ -1,0 +1,46 @@
+package io.github.sunday.devfolio.dto.portfolio;
+
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 포트폴리오 이미지 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioImageDto {
+    /**
+     * 이미지의 고유 식별자 (기본키)
+     */
+    private Long imageIdx;
+
+    /**
+     * 이미지가 속한 포트폴리오의 식별자
+     */
+    private Long portfolioIdx;
+
+    /**
+     * 이미지의 URL(AWS S3)
+     */
+    private String imageUrl;
+
+    /**
+     * 이미지의 썸네일 여부
+     */
+    private Boolean isThumbnail;
+
+    /**
+     * 생성일
+     */
+    private ZonedDateTime createdAt;
+
+    /**
+     * 만료일
+     */
+    private ZonedDateTime expireAt;
+
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioImageDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioImageDto.java
@@ -32,15 +32,4 @@ public class PortfolioImageDto {
      * 이미지의 썸네일 여부
      */
     private Boolean isThumbnail;
-
-    /**
-     * 생성일
-     */
-    private ZonedDateTime createdAt;
-
-    /**
-     * 만료일
-     */
-    private ZonedDateTime expireAt;
-
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteDto.java
@@ -1,7 +1,0 @@
-package io.github.sunday.devfolio.dto.portfolio;
-
-/**
- * 포트폴리오 작성 요청 데이터를 받는 DTO
- */
-public class PortfolioWriteDto {
-}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
@@ -1,5 +1,6 @@
 package io.github.sunday.devfolio.dto.portfolio;
 
+import io.github.sunday.devfolio.annotation.portfolio.PortfolioCategoryValid;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -47,7 +48,8 @@ public class PortfolioWriteRequestDto {
     /**
      * 포트폴리오 카테고리
      */
-    private List<Integer> categories = new ArrayList<>();
+    @PortfolioCategoryValid
+    private List<Long> categories = new ArrayList<>();
 
     /**
      * 포트폴리오 썸네일 이미지

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
@@ -1,5 +1,6 @@
 package io.github.sunday.devfolio.dto.portfolio;
 
+import io.github.sunday.devfolio.annotation.common.DateValid;
 import io.github.sunday.devfolio.annotation.portfolio.PortfolioCategoryValid;
 import jakarta.validation.constraints.*;
 import lombok.*;
@@ -18,7 +19,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class PortfolioWriteRequestDto {
-
     /**
      * 포트폴리오 제목
      */
@@ -30,13 +30,13 @@ public class PortfolioWriteRequestDto {
     /**
      * 프로젝트 시작일
      */
-    @Pattern(regexp = "", message = "잘못된 날짜 형식입니다.")
+    @DateValid
     private LocalDate startDate;
 
     /**
      * 프로젝트 종료일
      */
-    @Pattern(regexp = "", message = "잘못된 날짜 형식입니다.")
+    @DateValid
     private LocalDate endDate;
 
     /**

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioWriteRequestDto.java
@@ -54,15 +54,13 @@ public class PortfolioWriteRequestDto {
     /**
      * 포트폴리오 썸네일 이미지
      */
-    // Todo : 파일 확장자 검증 로직 필요
     private MultipartFile thumbnail;
 
     /**
      * 포트폴리오 이미지
      */
-    // Todo : 파일 확장자 검증 로직 필요
     @Size(max = 50, message = "이미지는 최대 50까지 업로드할 수 있습니다.")
-    private List<MultipartFile> images;
+    private List<String> images;
 
     /**
      * 프로젝트 날짜 검증

--- a/src/main/java/io/github/sunday/devfolio/annotation/common/DateValid.java
+++ b/src/main/java/io/github/sunday/devfolio/annotation/common/DateValid.java
@@ -1,0 +1,20 @@
+package io.github.sunday.devfolio.annotation.common;
+
+import io.github.sunday.devfolio.validator.common.DateValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+/**
+ * 날짜 String 형식이 yyyy-MM-dd 형식이면서 실제 날짜인지 검증하는 커스텀 어노테이션
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DateValidator.class)
+@Documented
+public @interface DateValid {
+    String message() default "올바른 날짜 형식이 아니거나 존재하지 않는 날짜입니다. (yyyy-MM-dd)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/io/github/sunday/devfolio/config/AppConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/AppConfig.java
@@ -1,9 +1,0 @@
-package io.github.sunday.devfolio.config;
-
-/**
- * 앱 설정용 킄래스입니다
- * 필요 없을 시 제거
- */
-public class AppConfig {
-
-}

--- a/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
@@ -1,8 +1,6 @@
 package io.github.sunday.devfolio.controller.common;
 
 import io.github.sunday.devfolio.dto.common.ImageUploadResult;
-import io.github.sunday.devfolio.enums.ImageTarget;
-import io.github.sunday.devfolio.exception.common.IncorrectImageTargetException;
 import io.github.sunday.devfolio.service.common.SecureImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
@@ -1,10 +1,13 @@
 package io.github.sunday.devfolio.controller.common;
 
 import io.github.sunday.devfolio.dto.common.ImageUploadResult;
+import io.github.sunday.devfolio.enums.ImageTarget;
+import io.github.sunday.devfolio.exception.common.IncorrectImageTargetException;
 import io.github.sunday.devfolio.service.common.SecureImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartRequest;
@@ -12,18 +15,25 @@ import org.springframework.web.multipart.MultipartRequest;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * CKEditor 이미지 업로드 관리 Controller
+ */
 @RestController
 @RequiredArgsConstructor
 public class EditorImageController {
     private final SecureImageService secureImageService;
 
     @PostMapping("/image/upload")
-    public ResponseEntity<Map<String, Object>> imageUpload(MultipartRequest request) {
+    public ResponseEntity<Map<String, Object>> imageUpload(
+            @RequestParam String target,
+            MultipartRequest request
+    ) {
         Map<String, Object> responseData = new HashMap<>();
-        String filePath = "temp";
-        MultipartFile image = request.getFile("upload");
         try {
-            ImageUploadResult uploadResult = secureImageService.uploadImage(image, filePath);
+            // Todo : 사용자 IDX 가져오기
+            Long userIdx = 1L;
+            MultipartFile image = request.getFile("upload");
+            ImageUploadResult uploadResult = secureImageService.uploadTempImage(image, target, userIdx);
             responseData.put("uploaded", true);
             responseData.put("url", uploadResult.getImageUrl());
         } catch (Exception e) {

--- a/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/EditorImageController.java
@@ -1,0 +1,35 @@
+package io.github.sunday.devfolio.controller.common;
+
+import io.github.sunday.devfolio.dto.common.ImageUploadResult;
+import io.github.sunday.devfolio.service.common.SecureImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class EditorImageController {
+    private final SecureImageService secureImageService;
+
+    @PostMapping("/image/upload")
+    public ResponseEntity<Map<String, Object>> imageUpload(MultipartRequest request) {
+        Map<String, Object> responseData = new HashMap<>();
+        String filePath = "temp";
+        MultipartFile image = request.getFile("upload");
+        try {
+            ImageUploadResult uploadResult = secureImageService.uploadImage(image, filePath);
+            responseData.put("uploaded", true);
+            responseData.put("url", uploadResult.getImageUrl());
+        } catch (Exception e) {
+            responseData.put("error", "image upload failed");
+            return ResponseEntity.badRequest().body(responseData);
+        }
+        return ResponseEntity.ok(responseData);
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
@@ -36,7 +36,7 @@ public class PortfolioController {
     /**
      * 포트폴리오 검색 요청이 들어올 때 DTO 내의 String에서 script를 제거
      */
-    @InitBinder("requestDto")
+    @InitBinder("searchRequestDto")
     public void initBinder(WebDataBinder binder) {
         // keyword와 category의 sanitize 수행
         binder.registerCustomEditor(String.class, new StringTrimmerEditor(true) {
@@ -65,12 +65,30 @@ public class PortfolioController {
     }
 
     /**
+     * 포트폴리오 작성 요청이 들어올 때 DTO 내의 String에서 script를 제거
+     */
+    @InitBinder({"writeRequestDto", "editRequestDto"})
+    public void initBinderToWrite(WebDataBinder binder) {
+        binder.registerCustomEditor(String.class, new StringTrimmerEditor(true) {
+            @Override
+            public void setAsText(String text) {
+                if (text != null) {
+                    String safeText = Jsoup.clean(text, Safelist.basic());
+                    super.setAsText(safeText.trim());
+                } else {
+                    super.setValue(null);
+                }
+            }
+        });
+    }
+
+    /**
      * 포트폴리오 메인 페이지 출력
      * 포트폴리오 검색, 핫한 포트폴리오 제공
      */
     @GetMapping()
     public String list(
-            @Valid @ModelAttribute PortfolioSearchRequestDto requestDto,
+            @Valid @ModelAttribute("searchRequestDto") PortfolioSearchRequestDto requestDto,
             BindingResult bindingResult,
             Model model
     ) {
@@ -136,7 +154,7 @@ public class PortfolioController {
     // Todo : 전역 에러 처리 설정 필요
     @PostMapping("/new")
     public String write(
-            @ModelAttribute PortfolioWriteRequestDto writeDto,
+            @ModelAttribute("writeRequestDto") PortfolioWriteRequestDto writeDto,
             BindingResult bindingResult,
             Model model
             ) {

--- a/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Safelist;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -106,8 +105,14 @@ public class PortfolioController {
         return "portfolio/portfolio";
     }
 
+    /**
+     * 포트폴리오 상세 페이지 출력
+     */
     @GetMapping("/{id}")
-    public String detail(@PathVariable Long id) {
+    public String detail(
+            @PathVariable Long id,
+            Model model
+    ) {
         return "portfolio/portfolio_detail";
     }
 
@@ -125,18 +130,48 @@ public class PortfolioController {
         return "portfolio/portfolio_write";
     }
 
+    /**
+     * 포트폴리오 작성 동작
+     */
+    // Todo : 전역 에러 처리 설정 필요
     @PostMapping("/new")
-    public ResponseEntity<?> write(
-            @ModelAttribute PortfolioWriteRequestDto writeDto
+    public String write(
+            @ModelAttribute PortfolioWriteRequestDto writeDto,
+            BindingResult bindingResult,
+            Model model
             ) {
-        return ResponseEntity.ok().build();
+
+        if (bindingResult.hasErrors()) {
+            List<PortfolioCategoryDto> categories = portfolioCategoryService.getCachedCategories();
+            model.addAttribute("writeDto", writeDto);
+            model.addAttribute("categories", categories);
+            return "portfolio/portfolio_write";
+        }
+        // Todo : 로그인한 사용자 정보 전달
+        Long testUserIdx = 1L;
+        Long portfolioIdx = portfolioService.addNewPortfolio(writeDto, testUserIdx);
+        return "redirect:/portfolio_detail/" + portfolioIdx;
     }
 
     /**
      * 포트폴리오 수정 페이지 출력
      */
     @GetMapping("/{id}/edit")
-    public String edit(@PathVariable Long id) {
+    public String editPage(
+            @PathVariable Long id,
+            Model model
+    ) {
+        return "portfolio/portfolio_edit";
+    }
+
+    /**
+     * 포트폴리오 수정
+     */
+    @PostMapping("/{id}/edit")
+    public String edit(
+            @PathVariable Long id,
+            Model model
+    ) {
         return "portfolio/portfolio_edit";
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/Portfolio.java
+++ b/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/Portfolio.java
@@ -106,7 +106,12 @@ public class Portfolio {
     /**
      * 검색을 위한 tsvector
      */
-    @Column(name = "search_vector", columnDefinition = "tsvector")
+    @Column(
+            name = "search_vector",
+            columnDefinition = "tsvector",
+            insertable = false,
+            updatable = false
+    )
     private String searchVector;
 
     @ManyToOne

--- a/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/PortfolioImage.java
+++ b/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/PortfolioImage.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -58,6 +59,18 @@ public class PortfolioImage {
     @Column(name = "is_thumbnail")
     @ColumnDefault("false")
     private Boolean isThumbnail;
+
+    /**
+     * 생성일
+     */
+    @Column(name = "created_at")
+    private ZonedDateTime createdAt;
+
+    /**
+     * 만료일
+     */
+    @Column(name = "expire_at")
+    private ZonedDateTime expireAt;
 
     /**
      * 객체의 동등성 비교를 위한 equals 메서드

--- a/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/PortfolioImage.java
+++ b/src/main/java/io/github/sunday/devfolio/entity/table/portfolio/PortfolioImage.java
@@ -54,6 +54,16 @@ public class PortfolioImage {
     private String imageUrl;
 
     /**
+     * 이미지의 S3Key(AWS S3)
+     */
+    @Column(
+            length = 512,
+            name = "s3_key",
+            nullable = false
+    )
+    private String s3Key;
+
+    /**
      * 이미지의 썸네일 여부
      */
     @Column(name = "is_thumbnail")

--- a/src/main/java/io/github/sunday/devfolio/entity/table/user/User.java
+++ b/src/main/java/io/github/sunday/devfolio/entity/table/user/User.java
@@ -3,8 +3,6 @@ package io.github.sunday.devfolio.entity.table.user;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -40,6 +38,7 @@ public class User {
     /**
      * OAuth 제공자 이름 (예: GOOGLE, LOCAL)
      */
+    @Enumerated(EnumType.STRING)
     @Column(name = "oauth_provider", length = 50)
     private AuthProvider oauthProvider = AuthProvider.LOCAL;
 

--- a/src/main/java/io/github/sunday/devfolio/enums/ImageTarget.java
+++ b/src/main/java/io/github/sunday/devfolio/enums/ImageTarget.java
@@ -1,0 +1,26 @@
+package io.github.sunday.devfolio.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 이미지 대상 ENUM
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ImageTarget {
+    PROFILE("profile"),
+    PORTFOLIO("portfolio"),
+    COMMUNITY("community");
+
+    private final String targetName;
+
+    public static ImageTarget fromFieldName(String fieldName) {
+        for (ImageTarget target : values()) {
+            if (target.getTargetName().equalsIgnoreCase(fieldName)) {
+                return target;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/exception/common/ImageUploadException.java
+++ b/src/main/java/io/github/sunday/devfolio/exception/common/ImageUploadException.java
@@ -1,0 +1,10 @@
+package io.github.sunday.devfolio.exception.common;
+
+/**
+ * 이미지 업로드 실패 처리용 예외
+ */
+public class ImageUploadException extends Exception {
+    public ImageUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/exception/common/ImageValidationException.java
+++ b/src/main/java/io/github/sunday/devfolio/exception/common/ImageValidationException.java
@@ -1,0 +1,12 @@
+package io.github.sunday.devfolio.exception.common;
+
+import java.io.IOException;
+
+/**
+ * 이미지 유효성 검사 처리용 예외
+ */
+public class ImageValidationException extends IOException {
+    public ImageValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/exception/common/IncorrectImageTargetException.java
+++ b/src/main/java/io/github/sunday/devfolio/exception/common/IncorrectImageTargetException.java
@@ -1,0 +1,7 @@
+package io.github.sunday.devfolio.exception.common;
+
+public class IncorrectImageTargetException extends IllegalArgumentException{
+    public IncorrectImageTargetException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCategoryMapRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCategoryMapRepository.java
@@ -19,5 +19,5 @@ public interface PortfolioCategoryMapRepository extends JpaRepository<PortfolioC
     /**
      * 포트폴리오 매핑 관계 제거
      */
-    void deleteByPortfolioAndPortfolioCategory_CategoryIdx(Portfolio portfolio, Long categoryIdx);
+    void deleteByPortfolioAndCategory_CategoryIdx(Portfolio portfolio, Long categoryIdx);
 }

--- a/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCategoryMapRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCategoryMapRepository.java
@@ -1,7 +1,6 @@
 package io.github.sunday.devfolio.repository.portfolio;
 
 import io.github.sunday.devfolio.entity.table.portfolio.Portfolio;
-import io.github.sunday.devfolio.entity.table.portfolio.PortfolioCategory;
 import io.github.sunday.devfolio.entity.table.portfolio.PortfolioCategoryMap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -17,4 +16,8 @@ public interface PortfolioCategoryMapRepository extends JpaRepository<PortfolioC
      */
     List<PortfolioCategoryMap> findAllByPortfolio(Portfolio portfolio);
 
+    /**
+     * 포트폴리오 매핑 관계 제거
+     */
+    void deleteByPortfolioAndPortfolioCategory_CategoryIdx(Portfolio portfolio, Long categoryIdx);
 }

--- a/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCommentRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioCommentRepository.java
@@ -3,5 +3,15 @@ package io.github.sunday.devfolio.repository.portfolio;
 import io.github.sunday.devfolio.entity.table.portfolio.PortfolioComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
+/**
+ * 포트폴리오 댓글 리포지토리
+ */
 public interface PortfolioCommentRepository extends JpaRepository<PortfolioComment, Long> {
+
+    /**
+     * 포트폴리오 IDX로 모든 댓글 조회
+     */
+    List<PortfolioComment> findAllByPortfolio_PortfolioIdx(Long portfolioIdx);
 }

--- a/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioImageRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/portfolio/PortfolioImageRepository.java
@@ -4,6 +4,7 @@ import io.github.sunday.devfolio.entity.table.portfolio.Portfolio;
 import io.github.sunday.devfolio.entity.table.portfolio.PortfolioImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,4 +17,9 @@ public interface PortfolioImageRepository extends JpaRepository<PortfolioImage, 
      * 썸네일 여부를 확인하는 컬럼이 True인 이미지를 선택
      */
     Optional<PortfolioImage> findByPortfolio_PortfolioIdxAndIsThumbnailTrue(Long portfolioIdx);
+
+    /**
+     * 포트폴리오의 모든 이미지 찾기
+     */
+    List<PortfolioImage> findAllByPortfolio_PortfolioIdx(Long portfolioIdx);
 }

--- a/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
@@ -1,0 +1,94 @@
+package io.github.sunday.devfolio.service.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Amazon AWS S3 파일 관리를 위한 서비스
+ */
+@Service
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final String bucketName;
+
+    /**
+     * AWS S3 버킷 연결
+     */
+    public S3Service(
+            @Value("${aws.access-key-id}") String accessKey,
+            @Value("${aws.secret-access-key}") String secretKey,
+            @Value("${aws.region}") String region,
+            @Value("${aws.s3.bucket-name}") String bucketName) {
+
+        this.bucketName = bucketName;
+
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        this.s3Client = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    /**
+     * 파일 업로드
+     */
+    public String uploadFile(MultipartFile file, String filePath) throws IOException {
+        String fileName = generateFileName(filePath, file.getOriginalFilename());
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+        return getFileUrl(fileName);
+    }
+
+    /**
+     * 파일 URL 생성하기
+     */
+    public String getFileUrl(String fileName) {
+        S3Utilities s3Utilities = s3Client.utilities();
+        GetUrlRequest request = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Utilities.getUrl(request).toString();
+    }
+
+    /**
+     * 파일 제거하기
+     */
+    public void deleteFile(String fileName) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
+    /**
+     * 파일 이름 설정하기
+     * UUID 적용
+     */
+    private String generateFileName(String filePath, String originalFilename) {
+        return filePath + "/" + UUID.randomUUID().toString() + "-" + originalFilename;
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
@@ -11,8 +11,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.*;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -46,17 +46,16 @@ public class S3Service {
     /**
      * 파일 업로드
      */
-    public String uploadFile(MultipartFile file, String filePath) throws IOException {
-        String fileName = generateFileName(filePath, file.getOriginalFilename());
+    public String uploadFile(MultipartFile file, String fileFullPath) throws IOException {
 
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .key(fileName)
+                .key(fileFullPath)
                 .contentType(file.getContentType())
                 .build();
 
         s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
-        return getFileUrl(fileName);
+        return getFileUrl(fileFullPath);
     }
 
     /**
@@ -82,13 +81,5 @@ public class S3Service {
                 .build();
 
         s3Client.deleteObject(request);
-    }
-
-    /**
-     * 파일 이름 설정하기
-     * UUID 적용
-     */
-    private String generateFileName(String filePath, String originalFilename) {
-        return filePath + "/" + UUID.randomUUID().toString() + "-" + originalFilename;
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
@@ -1,8 +1,8 @@
 package io.github.sunday.devfolio.service.common;
 
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -12,8 +12,8 @@ import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
 import java.io.IOException;
-import java.util.UUID;
 
 /**
  * Amazon AWS S3 파일 관리를 위한 서비스
@@ -46,15 +46,16 @@ public class S3Service {
     /**
      * 파일 업로드
      */
-    public String uploadFile(MultipartFile file, String fileFullPath) throws IOException {
-
+    public String uploadFile(BufferedImage bufferedImage, String fileFullPath) throws IOException {
+        String contentType = "image/" + FilenameUtils.getExtension(fileFullPath);
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileFullPath)
-                .contentType(file.getContentType())
+                .contentType(contentType)
                 .build();
 
-        s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+        byte[] imageBytes = ((DataBufferByte)bufferedImage.getData().getDataBuffer()).getData();
+        s3Client.putObject(request, RequestBody.fromBytes(imageBytes));
         return getFileUrl(fileFullPath);
     }
 

--- a/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
@@ -3,6 +3,7 @@ package io.github.sunday.devfolio.service.common;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -11,8 +12,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.*;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
 import java.io.IOException;
 
 /**
@@ -46,7 +45,7 @@ public class S3Service {
     /**
      * 파일 업로드
      */
-    public String uploadFile(BufferedImage bufferedImage, String fileFullPath) throws IOException {
+    public String uploadFile(MultipartFile file, String fileFullPath) throws IOException {
         String contentType = "image/" + FilenameUtils.getExtension(fileFullPath);
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(bucketName)
@@ -54,8 +53,7 @@ public class S3Service {
                 .contentType(contentType)
                 .build();
 
-        byte[] imageBytes = ((DataBufferByte)bufferedImage.getData().getDataBuffer()).getData();
-        s3Client.putObject(request, RequestBody.fromBytes(imageBytes));
+        s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
         return getFileUrl(fileFullPath);
     }
 

--- a/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/S3Service.java
@@ -45,12 +45,13 @@ public class S3Service {
     /**
      * 파일 업로드
      */
-    public String uploadFile(MultipartFile file, String fileFullPath) throws IOException {
+    public String uploadFile(MultipartFile file, String fileFullPath, boolean isTemp) throws IOException {
         String contentType = "image/" + FilenameUtils.getExtension(fileFullPath);
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileFullPath)
                 .contentType(contentType)
+                .tagging(isTemp ? "lifecycle=TEMP" : null)
                 .build();
 
         s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
@@ -81,4 +82,5 @@ public class S3Service {
 
         s3Client.deleteObject(request);
     }
+
 }

--- a/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
@@ -1,0 +1,167 @@
+package io.github.sunday.devfolio.service.common;
+
+import io.github.sunday.devfolio.dto.common.ImageUploadResult;
+import io.github.sunday.devfolio.exception.common.ImageUploadException;
+import io.github.sunday.devfolio.exception.common.ImageValidationException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 이미지 파일을 검증하는 공통 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class SecureImageService {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/gif",
+            "image/webp"
+    );
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            "jpg", "jpeg", "png", "gif", "webp"
+    );
+
+    private final Tika tika = new Tika();
+    private final S3Service s3Service;
+
+    /**
+     * AWS S3에 파일 검증 후 이미지 파일 업로드
+     */
+    public ImageUploadResult uploadImage(MultipartFile file, String filePath) throws ImageUploadException {
+        try {
+            // 파일 검증
+            validateFile(file);
+
+            // 안전한 파일명 생성
+            String safeFileName = generateSafeFileName(file.getOriginalFilename());
+
+            // 이미지 리사이징
+            BufferedImage resizedImage = resizeImage(file.getInputStream());
+
+            // S3 업로드
+            String fileFullPath = String.format("%s/%s", filePath, safeFileName);
+
+            String imageUrl = s3Service.uploadFile(resizedImage, fileFullPath);
+
+            return ImageUploadResult.builder()
+                    .originalFileName(file.getOriginalFilename())
+                    .s3Key(fileFullPath)
+                    .imageUrl(imageUrl)
+                    .fileSize(file.getSize())
+                    .uploadedAt(ZonedDateTime.now())
+                    .build();
+
+        } catch (Exception e) {
+            throw new ImageUploadException("이미지 업로드 실패", e);
+        }
+    }
+
+    /**
+     * 파일 유효성 검사
+     */
+    private void validateFile(MultipartFile file) throws IOException {
+        // 파일 존재 여부
+        if (file == null || file.isEmpty()) {
+            throw new ImageValidationException("파일이 없습니다.");
+        }
+
+        // 파일 크기 검증
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new ImageValidationException("파일 크기는 10MB 이하여야 합니다.");
+        }
+
+        // 파일 확장자 검증
+        String extension = FilenameUtils.getExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+            throw new ImageValidationException("허용되지 않은 파일 형식입니다.");
+        }
+
+        // MIME 타입 검증 (Magic Number 기반)
+        String detectedMimeType = tika.detect(file.getInputStream());
+        if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
+            throw new ImageValidationException("허용되지 않은 파일 형식입니다.");
+        }
+
+        // 실제 이미지 파일인지 검증
+        try {
+            BufferedImage image = ImageIO.read(file.getInputStream());
+            if (image == null) {
+                throw new ImageValidationException("유효한 이미지 파일이 아닙니다.");
+            }
+
+            // 이미지 크기 제한
+            if (image.getWidth() > 5000 || image.getHeight() > 5000) {
+                throw new ImageValidationException("이미지 크기는 5000x5000 픽셀 이하여야 합니다.");
+            }
+        } catch (IOException e) {
+            throw new ImageValidationException("이미지 파일을 읽을 수 없습니다.");
+        }
+    }
+
+    /**
+     * 파일 이름 생성하기
+     */
+    private String generateSafeFileName(String originalFileName) {
+        String baseName = FilenameUtils.getBaseName(originalFileName);
+        String extension = FilenameUtils.getExtension(originalFileName);
+
+        // 특수문자 제거
+        baseName = baseName.replaceAll("[^a-zA-Z0-9가-힣._-]", "");
+
+        // UUID 추가로 중복 방지
+        return String.format("%s_%s.%s",
+                baseName,
+                UUID.randomUUID().toString().substring(0, 8),
+                extension.toLowerCase());
+    }
+
+    /**
+     * 이미지 크기 조정
+     */
+    private BufferedImage resizeImage(InputStream inputStream) throws IOException {
+        BufferedImage originalImage = ImageIO.read(inputStream);
+
+        // 최대 너비/높이 설정
+        int maxDimension = 1920;
+
+        if (originalImage.getWidth() <= maxDimension &&
+                originalImage.getHeight() <= maxDimension) {
+            return originalImage;
+        }
+
+        // 비율 유지하며 리사이징
+        double scale = Math.min(
+                (double) maxDimension / originalImage.getWidth(),
+                (double) maxDimension / originalImage.getHeight()
+        );
+
+        int newWidth = (int) (originalImage.getWidth() * scale);
+        int newHeight = (int) (originalImage.getHeight() * scale);
+
+        BufferedImage resizedImage = new BufferedImage(newWidth, newHeight,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = resizedImage.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2d.drawImage(originalImage, 0, 0, newWidth, newHeight, null);
+        g2d.dispose();
+
+        return resizedImage;
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
@@ -90,7 +90,7 @@ public class PortfolioCategoryService {
         portfolioCategoryIdxList
                 .forEach(idx ->
                     portfolioCategoryMapRepository
-                            .deleteByPortfolioAndPortfolioCategory_CategoryIdx(portfolio, idx)
+                            .deleteByPortfolioAndCategory_CategoryIdx(portfolio, idx)
                 );
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
@@ -1,7 +1,9 @@
 package io.github.sunday.devfolio.service.portfolio;
 
 import io.github.sunday.devfolio.dto.portfolio.PortfolioCategoryDto;
+import io.github.sunday.devfolio.entity.table.portfolio.Portfolio;
 import io.github.sunday.devfolio.entity.table.portfolio.PortfolioCategory;
+import io.github.sunday.devfolio.entity.table.portfolio.PortfolioCategoryMap;
 import io.github.sunday.devfolio.repository.portfolio.PortfolioCategoryMapRepository;
 import io.github.sunday.devfolio.repository.portfolio.PortfolioCategoryRepository;
 import jakarta.annotation.PostConstruct;
@@ -49,7 +51,21 @@ public class PortfolioCategoryService {
                 .anyMatch(category -> category.getCategoryIdx().equals(categoryIdx));
     }
 
-    // Todo : 카테고리 매핑 추가
+    /**
+     * 포트폴리오와 카테고리 매핑 데이터 추가
+     */
+    public void addPortfolioCategoryMap(Portfolio portfolio, List<Long> portfolioCategoryIdxList) {
+        portfolioCategoryIdxList
+                .forEach(idx -> {
+                    PortfolioCategory category = portfolioCategoryRepository.findById(idx).orElse(null);
+                    if (category == null) return;
+                    PortfolioCategoryMap categoryMap = PortfolioCategoryMap.builder()
+                            .portfolio(portfolio)
+                            .category(category)
+                            .build();
+                    portfolioCategoryMapRepository.save(categoryMap);
+                });
+    }
     
     // Todo : 카테고리 매핑 제거
 }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
@@ -52,6 +52,22 @@ public class PortfolioCategoryService {
     }
 
     /**
+     * 포트폴리오 카테고리 목록 조회
+     */
+    public List<PortfolioCategoryDto> getCategoriesByPortfolio(Portfolio portfolio) {
+        List<PortfolioCategoryMap> mapList = portfolioCategoryMapRepository.findAllByPortfolio(portfolio);
+        return mapList.stream()
+                .map(map -> {
+                    PortfolioCategory category = map.getCategory();
+                    return PortfolioCategoryDto.builder()
+                            .categoryIdx(category.getCategoryIdx())
+                            .name(category.getName())
+                            .nameKo(category.getNameKo())
+                            .build();
+                }).toList();
+    }
+
+    /**
      * 포트폴리오와 카테고리 매핑 데이터 추가
      */
     public void addPortfolioCategoryMap(Portfolio portfolio, List<Long> portfolioCategoryIdxList) {
@@ -66,6 +82,15 @@ public class PortfolioCategoryService {
                     portfolioCategoryMapRepository.save(categoryMap);
                 });
     }
-    
-    // Todo : 카테고리 매핑 제거
+
+    /**
+     * 포트폴리오와 카테고리 매핑 관계 제거
+     */
+    public void removePortfolioCategoryMap(Portfolio portfolio, List<Long> portfolioCategoryIdxList) {
+        portfolioCategoryIdxList
+                .forEach(idx ->
+                    portfolioCategoryMapRepository
+                            .deleteByPortfolioAndPortfolioCategory_CategoryIdx(portfolio, idx)
+                );
+    }
 }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCommentService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCommentService.java
@@ -1,0 +1,62 @@
+package io.github.sunday.devfolio.service.portfolio;
+
+import io.github.sunday.devfolio.dto.portfolio.PortfolioCommentDto;
+import io.github.sunday.devfolio.dto.user.WriterDto;
+import io.github.sunday.devfolio.entity.table.portfolio.PortfolioComment;
+import io.github.sunday.devfolio.entity.table.user.User;
+import io.github.sunday.devfolio.repository.portfolio.PortfolioCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 포트폴리오의 댓글 Entity를 관리하는 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class PortfolioCommentService {
+    private final PortfolioCommentRepository portfolioCommentRepository;
+    
+    // Todo : 포트폴리오 댓글 조회
+    public List<PortfolioCommentDto> getPortfolioComments(Long portfolioIdx) {
+        List<PortfolioComment> comments = portfolioCommentRepository.findAllByPortfolio_PortfolioIdx(portfolioIdx);
+        // Todo : 대댓글 구조 반영
+        return comments.stream().map(comment -> commentToDto(comment))
+                .toList();
+    }
+    
+    // Todo : 포트폴리오 댓글 추가
+    
+    // Todo : 포트폴리오 댓글 수정
+    
+    // Todo : 포트폴리오 댓글 삭제
+
+    // Todo : 포트폴리오 대댓글 조회
+
+    // Todo : 포트폴리오 대댓글 추가
+
+    // Todo : 포트폴리오 대댓글 수정
+
+    // Todo : 포트폴리오 대댓글 삭제
+
+    // Todo : Entity To Dto
+    private PortfolioCommentDto commentToDto(PortfolioComment comment) {
+        return PortfolioCommentDto.builder()
+                .commentIdx(comment.getCommentIdx())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .writer(userToWriterDto(comment.getUser()))
+                .portfolioIdx(comment.getPortfolio().getPortfolioIdx())
+                .build();
+    }
+
+    private WriterDto userToWriterDto(User user) {
+        return WriterDto.builder()
+                .userIdx(user.getUserIdx())
+                .nickname(user.getNickname())
+                .profileImg(user.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
@@ -45,7 +45,8 @@ public class PortfolioImageService {
         String filePath = "portfolio/" + portfolio.getPortfolioIdx();
         PortfolioImage thumbnailImage = addNewImage(writeRequestDto.getThumbnail(), filePath, true);
         // Todo : 이미지 이동 처리
-        //List<PortfolioImage> imageList = addNewImageList(writeRequestDto.getImages(), filePath);
+        List<String> imageList = writeRequestDto.getImages();
+        imageList.forEach(image -> System.out.println(image));
 
         // DB에 이미지 추가
         savePortfolioImage(portfolio, thumbnailImage);

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
@@ -41,14 +41,13 @@ public class PortfolioImageService {
      * 포트폴리오 이미지 추가
      * DB에 Entity 추가 및 AWS S3에 이미지 파일 업로드
      */
-    public void addPortfolioImage(Portfolio portfolio, PortfolioWriteRequestDto writeRequestDto) throws Exception {
-        String filePath = "portfolio/" + portfolio.getPortfolioIdx();
+    public void addPortfolioImage(Portfolio portfolio, PortfolioWriteRequestDto writeRequestDto, Long userIdx) throws Exception {
+        String filePath = userIdx + "/portfolio/" + portfolio.getPortfolioIdx();
         PortfolioImage thumbnailImage = addNewImage(writeRequestDto.getThumbnail(), filePath, true);
-        // Todo : 이미지 이동 처리
         List<String> imageList = writeRequestDto.getImages();
-        imageList.forEach(image -> System.out.println(image));
 
         // DB에 이미지 추가
+        // Todo : Image Entity 추가가 안되는 에러 수정
         savePortfolioImage(portfolio, thumbnailImage);
         //imageList.forEach(image -> savePortfolioImage(portfolio, image));
     }
@@ -77,7 +76,7 @@ public class PortfolioImageService {
      */
     // Todo : 예외 처리 로직 추가
     private PortfolioImage addNewImage(MultipartFile file, String filePath, boolean isThumbnail) throws ImageUploadException{
-        ImageUploadResult uploadResult = secureImageService.uploadImage(file, filePath);
+        ImageUploadResult uploadResult = secureImageService.uploadImage(file, filePath, false);
 
         return PortfolioImage.builder()
                 .imageUrl(uploadResult.getImageUrl())

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.net.URLDecoder;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -43,13 +42,14 @@ public class PortfolioImageService {
      * DB에 Entity 추가 및 AWS S3에 이미지 파일 업로드
      */
     public void addPortfolioImage(Portfolio portfolio, PortfolioWriteRequestDto writeRequestDto) throws Exception {
-        String filePath = "/portfolio/" + portfolio.getPortfolioIdx();
+        String filePath = "portfolio/" + portfolio.getPortfolioIdx();
         PortfolioImage thumbnailImage = addNewImage(writeRequestDto.getThumbnail(), filePath, true);
-        List<PortfolioImage> imageList = addNewImageList(writeRequestDto.getImages(), filePath);
+        // Todo : 이미지 이동 처리
+        //List<PortfolioImage> imageList = addNewImageList(writeRequestDto.getImages(), filePath);
 
         // DB에 이미지 추가
         savePortfolioImage(portfolio, thumbnailImage);
-        imageList.forEach(image -> savePortfolioImage(portfolio, image));
+        //imageList.forEach(image -> savePortfolioImage(portfolio, image));
     }
 
     /**

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioImageService.java
@@ -1,0 +1,48 @@
+package io.github.sunday.devfolio.service.portfolio;
+
+import io.github.sunday.devfolio.dto.portfolio.PortfolioImageDto;
+import io.github.sunday.devfolio.entity.table.portfolio.PortfolioImage;
+import io.github.sunday.devfolio.repository.portfolio.PortfolioImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 포트폴리오의 이미지 Entity를 관리하는 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class PortfolioImageService {
+    private final PortfolioImageRepository portfolioImageRepository;
+    
+    // Todo : 포트폴리오의 이미지 조회
+    public List<PortfolioImageDto> getPortfolioImages(Long portfolioIdx) {
+        return portfolioImageRepository.findAllByPortfolio_PortfolioIdx(portfolioIdx)
+                .stream()
+                .map(this::imageToDto)
+                .toList();
+    }
+    
+    // Todo : 포트폴리오의 이미지 추가
+    public void addNewImages() {
+        // 이미지 추가 동작 - AWS S3 연동
+    }
+    
+    
+    // Todo : 포트폴리오의 이미지 제거
+    public void removeImages() {
+        // 이미지 삭제 동작 - AWS S3 연동
+    }
+
+    private PortfolioImageDto imageToDto(PortfolioImage image) {
+        return PortfolioImageDto.builder()
+                .imageIdx(image.getImageIdx())
+                .portfolioIdx(image.getPortfolio().getPortfolioIdx())
+                .imageUrl(image.getImageUrl())
+                .isThumbnail(image.getIsThumbnail())
+                .createdAt(image.getCreatedAt())
+                .expireAt(image.getExpireAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -139,6 +139,10 @@ public class PortfolioService {
         // 요청을 받는다
         // 사용자 정보를 가져온다
         User user = userService.findByUserIdx(userIdx);
+        if (user == null) {
+            return null;
+        }
+
         Portfolio portfolio = writeDtoToPortfolio(writeRequestDto, user);
 
         // 데이터를 저장한다
@@ -151,7 +155,7 @@ public class PortfolioService {
         // Todo : 에러 핸들링
         try {
             portfolioImageService.addPortfolioImage(portfolio, writeRequestDto);
-        } catch (IOException e) {}
+        } catch (Exception e) {}
 
         return newPortfolio.getPortfolioIdx();
     }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -136,8 +135,7 @@ public class PortfolioService {
      * 포트폴리오 데이터, 포트폴리오 카테고리, 썸네일 이미지, 포트폴리오 이미지 저장
      */
     public Long addNewPortfolio(PortfolioWriteRequestDto writeRequestDto, Long userIdx) {
-        // 요청을 받는다
-        // 사용자 정보를 가져온다
+        // 사용자 검색
         User user = userService.findByUserIdx(userIdx);
         if (user == null) {
             return null;
@@ -145,13 +143,12 @@ public class PortfolioService {
 
         Portfolio portfolio = writeDtoToPortfolio(writeRequestDto, user);
 
-        // 데이터를 저장한다
-        // id값을 반한다
+        // 포트폴리오 데이터 저장
         Portfolio newPortfolio = portfolioRepository.save(portfolio);
-        // 포트폴리오 카테고리를 저장한다.
+        // 포트폴리오 카테고리를 저장
         portfolioCategoryService.addPortfolioCategoryMap(newPortfolio, writeRequestDto.getCategories());
 
-        // 이미지 파일을 저장한다
+        // 이미지 파일 저장
         // Todo : 에러 핸들링
         try {
             portfolioImageService.addPortfolioImage(portfolio, writeRequestDto);

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -151,7 +151,7 @@ public class PortfolioService {
         // 이미지 파일 저장
         // Todo : 에러 핸들링
         try {
-            portfolioImageService.addPortfolioImage(portfolio, writeRequestDto);
+            portfolioImageService.addPortfolioImage(portfolio, writeRequestDto, userIdx);
         } catch (Exception e) {}
 
         return newPortfolio.getPortfolioIdx();

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -147,7 +148,10 @@ public class PortfolioService {
         portfolioCategoryService.addPortfolioCategoryMap(newPortfolio, writeRequestDto.getCategories());
 
         // 이미지 파일을 저장한다
-        // portfolioImageService.addNewImages();
+        // Todo : 에러 핸들링
+        try {
+            portfolioImageService.addPortfolioImage(portfolio, writeRequestDto);
+        } catch (IOException e) {}
 
         return newPortfolio.getPortfolioIdx();
     }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -152,7 +152,9 @@ public class PortfolioService {
         // Todo : 에러 핸들링
         try {
             portfolioImageService.addPortfolioImage(portfolio, writeRequestDto, userIdx);
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
         return newPortfolio.getPortfolioIdx();
     }

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -1,16 +1,12 @@
 package io.github.sunday.devfolio.service.portfolio;
 
-import io.github.sunday.devfolio.dto.portfolio.PortfolioPageRequestDto;
-import io.github.sunday.devfolio.dto.portfolio.PortfolioLikeListDto;
-import io.github.sunday.devfolio.dto.portfolio.PortfolioListDto;
-import io.github.sunday.devfolio.dto.portfolio.PortfolioSearchRequestDto;
+import io.github.sunday.devfolio.dto.portfolio.*;
+import io.github.sunday.devfolio.entity.table.portfolio.*;
 import io.github.sunday.devfolio.enums.PortfolioSort;
 import io.github.sunday.devfolio.dto.user.WriterDto;
-import io.github.sunday.devfolio.entity.table.portfolio.Portfolio;
-import io.github.sunday.devfolio.entity.table.portfolio.PortfolioImage;
-import io.github.sunday.devfolio.entity.table.portfolio.PortfolioLike;
 import io.github.sunday.devfolio.entity.table.user.User;
 import io.github.sunday.devfolio.repository.portfolio.*;
+import io.github.sunday.devfolio.service.impl.UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,10 +27,10 @@ import java.util.List;
 public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
     private final PortfolioQueryDslRepository portfolioQueryDslRepository;
-    private final PortfolioCategoryMapRepository portfolioCategoryMapRepository;
-    private final PortfolioCommentRepository portfolioCommentRepository;
     private final PortfolioImageRepository portfolioImageRepository;
     private final PortfolioLikeRepository portfolioLikeRepository;
+    private final PortfolioCategoryService portfolioCategoryService;
+    private final UserServiceImpl userService;
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     /**
@@ -92,9 +88,26 @@ public class PortfolioService {
 
     // Todo : 포트폴리오 상세보기 기능 추가
 
+    /**
+     * 포트폴리오 저장
+     * 포트폴리오 데이터, 포트폴리오 카테고리, 썸네일 이미지, 포트폴리오 이미지 저장
+     */
+    public Long addNewPortfolio(PortfolioWriteRequestDto writeRequestDto, Long userIdx) {
+        // 요청을 받는다
+        // 사용자 정보를 가져온다
+        User user = userService.findByUserIdx(userIdx);
+        Portfolio portfolio = writeDtoToPortfolio(writeRequestDto, user);
 
-    // Todo : 포트폴리오 작성 기능 추가
+        // 데이터를 저장한다
+        // id값을 반한다
+        Portfolio newPortfolio = portfolioRepository.save(portfolio);
+        // 포트폴리오 카테고리를 저장한다.
+        portfolioCategoryService.addPortfolioCategoryMap(newPortfolio, writeRequestDto.getCategories());
 
+        // 이미지 파일을 저장한다
+
+        return newPortfolio.getPortfolioIdx();
+    }
 
     // Todo : 포트폴리오 수정 기능 추가
 
@@ -183,5 +196,20 @@ public class PortfolioService {
                             .likedAt(portfolioLike.getLikedAt().format(formatter))
                             .build();
                 }).toList();
+    }
+
+    private Portfolio writeDtoToPortfolio(PortfolioWriteRequestDto writeRequestDto, User user) {
+        return Portfolio.builder()
+                .title(writeRequestDto.getTitle())
+                .startDate(writeRequestDto.getStartDate())
+                .endDate(writeRequestDto.getEndDate())
+                .description(writeRequestDto.getDescription())
+                .views(0)
+                .likeCount(0)
+                .commentCount(0)
+                .createdAt(ZonedDateTime.now())
+                .updatedAt(ZonedDateTime.now())
+                .user(user)
+                .build();
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/validator/common/DateValidator.java
+++ b/src/main/java/io/github/sunday/devfolio/validator/common/DateValidator.java
@@ -1,0 +1,32 @@
+package io.github.sunday.devfolio.validator.common;
+
+import io.github.sunday.devfolio.annotation.common.DateValid;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * 날짜 형식을 검증하는 Validator
+ * yyyy-MM-dd 형식을 검증
+ * 실제 존재하는 날짜인지 검증(예: 윤년 등)
+ */
+public class DateValidator implements ConstraintValidator<DateValid, String> {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+
+        try {
+            LocalDate.parse(value, FORMATTER);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/validator/portfolio/PortfolioCategoryValidator.java
+++ b/src/main/java/io/github/sunday/devfolio/validator/portfolio/PortfolioCategoryValidator.java
@@ -7,20 +7,34 @@ import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * 포트폴리오 카테고리 검증을 위한 Validator
  */
 @Component
 @RequiredArgsConstructor
-public class PortfolioCategoryValidator implements ConstraintValidator<PortfolioCategoryValid, Long> {
+public class PortfolioCategoryValidator implements ConstraintValidator<PortfolioCategoryValid, Object> {
     private final PortfolioCategoryService portfolioCategoryService;
 
     /**
      * 포트폴리오 카테고리 서비스의 메서드로 값 검증 진행
+     * 단일 Long id와 리스트 Long 모두 검증 가능
      */
     @Override
-    public boolean isValid(Long value, ConstraintValidatorContext context) {
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
         if (value == null) return true;
-        return portfolioCategoryService.exists(value);
+
+        if (value instanceof Long id) {
+            return portfolioCategoryService.exists(id);
+        }
+
+        if (value instanceof List<?> list) {
+            return list.stream()
+                    .filter(Long.class::isInstance)
+                    .map(Long.class::cast)
+                    .allMatch(portfolioCategoryService::exists);
+        }
+        return false;
     }
 }

--- a/src/main/resources/static/css/portfolio/portfolio_write.css
+++ b/src/main/resources/static/css/portfolio/portfolio_write.css
@@ -322,6 +322,7 @@ main {
     border-radius: var(--box-radius-15);
     background-color: white;
     gap: 20px;
+    z-index: 20;
 }
 
 .template-list {
@@ -348,6 +349,8 @@ main {
 }
 
 .template-list span {
+    width: 100%;
+    display: inline-block;
     font-size: 14px;
     color: #2F2F2F;
 }

--- a/src/main/resources/static/css/portfolio/portfolio_write.css
+++ b/src/main/resources/static/css/portfolio/portfolio_write.css
@@ -117,7 +117,7 @@ main {
     flex: 1;
 }
 
-.category-box span {
+.category-box > span:first-child {
     color: #919191;
     font-size: 14px;
 }
@@ -188,10 +188,22 @@ main {
 
 .image-preview img {
     width: 100%; height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+}
+
+#preview-image {
+    display: none;
+}
+
+#preview-image.visible {
+    display: block;
 }
 
 .img-remove-button {
+    display: none;
+}
+
+.img-remove-button.visible {
     padding: 5px;
     position: absolute;
     top: 10px; right: 10px;
@@ -230,7 +242,7 @@ main {
     display: none;
 }
 
-/* description */
+/* description, ckeditor */
 .textarea-input-group {
     flex-direction: column;
     align-items: flex-start;
@@ -238,7 +250,7 @@ main {
 
 .textarea-input-group .main-container,
 #editor-container, .textarea-input-group .editor-container__editor
- {
+{
     width: 100%;
 }
 
@@ -247,8 +259,12 @@ main {
     max-width: 100%;
 }
 
-#editor {
+.editor-container__editor p{
     width: 100%;
+}
+
+.ck-editor__editable_inline {
+    min-height: 600px;
 }
 
 /* button wrap */
@@ -279,6 +295,16 @@ main {
 
 .cancel-button {
     background-color: #B1B1B1;
+}
+
+.form-error {
+    display: none;
+}
+
+.form-error.visible {
+    display: block;
+    color: red;
+    font-size: 14px;
 }
 
 /* template select aside */

--- a/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
+++ b/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
@@ -307,12 +307,12 @@ export const editorConfig = {
 		contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties']
 	},
 	translations: [translations],
-	ckfinder: {
-		uploadUrl: '',
-		// Todo : Cookie 포함
-		// withCredentials: true
-		options: {
-			resourceType: 'Images'
-		}
-	}
+	 ckfinder: {
+	 	uploadUrl: '',
+	 	// Todo : Cookie 포함
+	 	// withCredentials: true
+	 	options: {
+	 		resourceType: 'Images'
+	 	}
+	 }
 };

--- a/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
+++ b/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
@@ -40,7 +40,6 @@ import {
 	List,
 	ListProperties,
 	Markdown,
-	MediaEmbed,
 	Paragraph,
 	PasteFromOffice,
 	SpecialCharacters,
@@ -59,7 +58,9 @@ import {
 	TableToolbar,
 	TextTransformation,
 	TodoList,
-	Underline
+	Underline,
+	CKFinder,
+	CKFinderUploadAdapter
 } from 'ckeditor5';
 
 import translations from 'ckeditor5/translations/ko.js';
@@ -85,7 +86,6 @@ export const editorConfig = {
 			'specialCharacters',
 			'link',
 			'insertImage',
-			'mediaEmbed',
 			'insertTable',
 			'blockQuote',
 			'codeBlock',
@@ -135,7 +135,6 @@ export const editorConfig = {
 		List,
 		ListProperties,
 		Markdown,
-		MediaEmbed,
 		Paragraph,
 		PasteFromOffice,
 		SpecialCharacters,
@@ -154,7 +153,9 @@ export const editorConfig = {
 		TableToolbar,
 		TextTransformation,
 		TodoList,
-		Underline
+		Underline,
+		CKFinder,
+		CKFinderUploadAdapter
 	],
 	fullscreen: {
 		onEnterCallback: container =>
@@ -305,5 +306,13 @@ export const editorConfig = {
 	table: {
 		contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties']
 	},
-	translations: [translations]
+	translations: [translations],
+	ckfinder: {
+		uploadUrl: '',
+		// Todo : Cookie 포함
+		// withCredentials: true
+		options: {
+			resourceType: 'Images'
+		}
+	}
 };

--- a/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
+++ b/src/main/resources/static/js/ckeditor5/ckeditor5-config.js
@@ -258,7 +258,6 @@ export const editorConfig = {
 			reversed: true
 		}
 	},
-	placeholder: '내용을 입력해주세요',
 	style: {
 		definitions: [
 			{

--- a/src/main/resources/static/js/portfolio/data/write-template.json
+++ b/src/main/resources/static/js/portfolio/data/write-template.json
@@ -1,0 +1,71 @@
+[
+    {
+        "idx": 0,
+        "description": "프로젝트 개요와 기술 스택을 중심으로 설명하는 포트폴리오 템플릿",
+        "headings": [
+            { "tagType": "heading2", "value": "프로젝트 포트폴리오" },
+            { "tagType": "heading2", "value": "프로젝트 개요" },
+            { "tagType": "heading3", "value": "프로젝트 제목" },
+            { "tagType": "heading3", "value": "한 줄 요약" },
+            { "tagType": "heading3", "value": "기간" },
+            { "tagType": "heading3", "value": "상태" },
+            { "tagType": "heading2", "value": "프로젝트 개요 (Overview)" },
+            { "tagType": "heading3", "value": "배경 및 도메인 (Context)" },
+            { "tagType": "heading3", "value": "문제 정의 및 목표 (Problem & Goals)" },
+            { "tagType": "heading3", "value": "주요 사용자 (Users)" },
+            { "tagType": "heading3", "value": "제약 조건 (Constraints)" },
+            { "tagType": "heading2", "value": "나의 역할 (Role)" },
+            { "tagType": "heading3", "value": "팀 규모 (Team Size)" },
+            { "tagType": "heading3", "value": "담당 업무 (Responsibilities)" },
+            { "tagType": "heading2", "value": "기술 스택 (Tech Stack)" },
+            { "tagType": "heading3", "value": "언어 (Languages)" },
+            { "tagType": "heading3", "value": "백엔드 (Backend)" },
+            { "tagType": "heading3", "value": "프론트엔드 (Frontend)" },
+            { "tagType": "heading3", "value": "데이터베이스 (Database)" },
+            { "tagType": "heading3", "value": "DevOps 및 CI/CD" },
+            { "tagType": "heading2", "value": "아키텍처 (Architecture)" },
+            { "tagType": "heading3", "value": "다이어그램 (Diagrams)" },
+            { "tagType": "heading3", "value": "주요 설계 결정 (Key Decisions)" },
+            { "tagType": "heading2", "value": "구현 내용 (Implementation)" },
+            { "tagType": "heading3", "value": "주요 기능 (Features)" },
+            { "tagType": "heading3", "value": "성능 및 보안 (Performance & Security)" },
+            { "tagType": "heading2", "value": "결과 및 성과 (Results)" },
+            { "tagType": "heading3", "value": "주요 지표 (Metrics & Outcomes)" },
+            { "tagType": "heading3", "value": "배운 점 (Learnings)" },
+            { "tagType": "heading2", "value": "시각 자료 및 링크 (Assets & Links)" },
+            { "tagType": "heading3", "value": "스크린샷" },
+            { "tagType": "heading3", "value": "데모/블로그/슬라이드 링크" },
+            { "tagType": "heading2", "value": "태그 및 라이선스 (tagTypes & License)" }
+        ]
+    },
+    {
+        "idx": 1,
+        "description": "문제 정의, 기술 설명, 데이터 방법론으로 구성된 사례 연구 포트폴리오 템플릿",
+        "headings": [
+            { "tagType": "heading2", "value": "사례 연구" },
+            { "tagType": "heading2", "value": "개요" },
+            { "tagType": "heading3", "value": "프로젝트 제목 및 간단 소개" },
+            { "tagType": "heading3", "value": "목표 및 배경" },
+            { "tagType": "heading2", "value": "핵심 요소" },
+            { "tagType": "heading3", "value": "(해당 Guide 이름) 핵심 개념" },
+            { "tagType": "heading3", "value": "관련 개념 1" },
+            { "tagType": "heading3", "value": "관련 개념 2" },
+            { "tagType": "heading2", "value": "도전 과제" },
+            { "tagType": "heading2", "value": "성찰 (회고)" }
+        ]
+    },
+    {
+        "idx": 2,
+        "description": "논문 스타일의 포트폴리오 템플릿",
+        "headings": [
+            { "tagType": "heading2", "value": "초록 (Abstract)" },
+            { "tagType": "heading2", "value": "서론 (Introduction)" },
+            { "tagType": "heading2", "value": "연구 방법 (Methods)" },
+            { "tagType": "heading2", "value": "연구 결과 (Results)" },
+            { "tagType": "heading2", "value": "논의 (Discussion)" },
+            { "tagType": "heading2", "value": "참고문헌 (References)" },
+            { "tagType": "heading2", "value": "표 및 그림 (Tables and Figures)" },
+            { "tagType": "heading2", "value": "부록 (Appendix)" }
+        ]
+    }
+]

--- a/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
@@ -2,7 +2,9 @@
 import { editorConfig } from 'ckeditor5Config';
 import { ClassicEditor } from 'ckeditor5';
 
-// CKEditor 초기화 함수
+/**
+ * CKEditor 초기화 함수
+ */
 function initializeEditor() {
     // 초기값 설정
     editorConfig['initialData'] = '<p>Hello</p>';
@@ -16,4 +18,4 @@ function initializeEditor() {
         });
 }
 
-initializeEditor();
+export default initializeEditor;

--- a/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
@@ -10,6 +10,7 @@ function initializeEditor() {
     editorConfig['initialData'] = '<p>Hello</p>';
     // Placeholder 설정
     editorConfig['placeholder'] = '내용을 입력해주세요';
+    editorConfig['ckfinder'] = { uploadUrl: '/image/upload' };
     // 에디터 적용
     ClassicEditor
         .create(document.getElementById("editor"), editorConfig)

--- a/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
@@ -6,65 +6,72 @@ import { ClassicEditor } from 'ckeditor5';
  * CKEditor 초기화 함수
  */
 function initializeEditor() {
-    // 초기값 설정
-    editorConfig['initialData'] = '<p>Hello</p>';
-    // Placeholder 설정
-    editorConfig['placeholder'] = '내용을 입력해주세요';
     editorConfig['ckfinder'] = { uploadUrl: '/image/upload?target=portfolio' };
     // 에디터 적용
     ClassicEditor
         .create(document.getElementById("editor"), editorConfig)
         .then(editor => {
             // 이미지 업로드 후 input 추가
-            const imageUploadEditing = editor.plugins.get('ImageUploadEditing');
-        
-            imageUploadEditing.on('uploadComplete', (evt, { data, imageElement }) => {
-                editor.model.change(writer => {
-                    writer.setAttribute('data-uploaded', 'true', imageElement);
-                });
-        
-                const viewImg = editor.editing.mapper.toViewElement(imageElement);
-                const domImg = editor.editing.view.domConverter.mapViewToDom(viewImg);
-
-                if (domImg) {
-                    const container = document.getElementById('image-list-box');
-                    if (container) {
-                        const input = document.createElement('input');
-                        input.type = 'hidden';
-                        input.name = 'images';
-                        input.value = data.default;
-                        container.appendChild(input);
-                    }
-                }
-            });
+            addImageInfoInput(editor);
 
             // 에디터에 등록한 이미지 제거 시 input 제거
-            const model = editor.model;
-            model.document.registerPostFixer(writer => {
-                const changes = model.document.differ.getChanges();
-                let handled = false;
+            removeImageInfoInput(editor);
 
-                for (const change of changes) {
-                    if (change.type === 'remove' && change.name === 'imageBlock') {
-                        handled = true;
-
-                        const removedImageSrc = change.attributes.get('src');
-                        const container = document.getElementById('image-list-box');
-                        if (container) {
-                            const input = container.querySelector(`input[name="images"][value="${removedImageSrc}"]`);
-                            if (input) input.remove();
-                        }
-                        handled = false;
-                        break;
-                    }
-                }
-
-                return handled;
-            });
+            window.editor = editor;
         })
         .catch(error => {
             console.error('CKEditor 초기화 중 오류 발생:', error);
         });
+}
+
+function addImageInfoInput(editor) {
+    // 이미지 업로드 후 input 추가
+    const imageUploadEditing = editor.plugins.get('ImageUploadEditing');
+
+    imageUploadEditing.on('uploadComplete', (evt, { data, imageElement }) => {
+        editor.model.change(writer => {
+            writer.setAttribute('data-uploaded', 'true', imageElement);
+        });
+
+        const viewImg = editor.editing.mapper.toViewElement(imageElement);
+        const domImg = editor.editing.view.domConverter.mapViewToDom(viewImg);
+
+        if (domImg) {
+            const container = document.getElementById('image-list-box');
+            if (container) {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = 'images';
+                input.value = data.default;
+                container.appendChild(input);
+            }
+        }
+    });
+}
+
+function removeImageInfoInput(editor) {
+    const model = editor.model;
+    model.document.registerPostFixer(writer => {
+        const changes = model.document.differ.getChanges();
+        let handled = false;
+
+        for (const change of changes) {
+            if (change.type === 'remove' && change.name === 'imageBlock') {
+                handled = true;
+
+                const removedImageSrc = change.attributes.get('src');
+                const container = document.getElementById('image-list-box');
+                if (container) {
+                    const input = container.querySelector(`input[name="images"][value="${removedImageSrc}"]`);
+                    if (input) input.remove();
+                }
+                handled = false;
+                break;
+            }
+        }
+
+        return handled;
+    });
 }
 
 export default initializeEditor;

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -1,4 +1,5 @@
 import initializeEditor from "./portfolio-write-ckeditor5.js";
+import templateData from "./data/write-template.json" with { type: "json" };
 
 /**
  * form 검증
@@ -95,10 +96,79 @@ function removePreviewImage(removeButton, preview, input) {
 }
 
 /**
+ * 포트폴리오 템플릿 추가 함수
+ */
+function addTemplate() {
+    const templateList = document.getElementsByClassName("template-list")[0];
+    const customTemplateLi = templateList.children[0];
+    templateData.forEach((data, index) => {
+        const elLi = document.createElement("li");
+        const inputGroup = document.createElement("div");
+        inputGroup.classList.add("radio-input-group");
+        
+        const radio = document.createElement("input");
+        radio.type = "radio";
+        radio.id = `template-${data.idx}`;
+        radio.name = "template";
+        radio.value = data.idx;
+        
+        const label = document.createElement("label");
+        label.htmlFor = `template-${data.idx}`;
+        label.textContent = `템플릿 ${data.idx+1}`;
+
+        inputGroup.appendChild(radio);
+        inputGroup.appendChild(label);
+        elLi.appendChild(inputGroup);
+
+        const templateDesc = document.createElement("span");
+        templateDesc.textContent = data.description;
+        elLi.appendChild(templateDesc);
+
+        templateList.insertBefore(elLi, customTemplateLi);
+    });
+    addTemplateEvent();
+
+    function addTemplateEvent() {
+        const radios = document.querySelectorAll('input[name="template"]');
+        radios.forEach(radio => {
+            radio.addEventListener("change", () => {
+                if (radio.checked) {
+                    const key = radio.value;
+                    const data = templateData[key];
+                    const headings = data.headings;
+                    addHeadingsToEditor(headings);
+                }
+            });
+        });
+    }
+
+    function addHeadingsToEditor(headings) {
+        
+        if (window.editor) {
+            const editor = window.editor;
+    
+            editor.model.change(writer => {
+                const insertPosition = editor.model.document.selection.getLastPosition();
+                console.log(insertPosition)
+
+                headings.forEach(heading => {
+                    const tagElement = writer.createElement(heading.tagType);
+                    writer.insertText(heading.value, tagElement);
+                    writer.append(tagElement, insertPosition);
+                });
+            });
+        } else {
+            setTimeout(() => addHeadingsToEditor(headings), 100);
+        }
+    }
+}
+
+/**
  * DOMContentLoaded 이벤트 리스너
  */
 document.addEventListener("DOMContentLoaded", () => {
     initializeEditor();
     validateForm();
     previewImage();
+    addTemplate();
 });

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -1,0 +1,74 @@
+import initializeEditor from "./portfolio-write-ckeditor5.js";
+
+/**
+ * form 검증
+ */
+function validateForm() {
+    const form = document.getElementById("write-form");
+    form.addEventListener("submit", (event) => {
+        validateCategory(event);
+    });
+}
+
+/**
+ * 카테고리 체크박스 검증
+ */
+function validateCategory(event) {
+    const categories = document.querySelectorAll(".category-list input[type='checkbox']");
+    const checkedCategories = Array.from(categories).filter(category => category.checked);
+    if (checkedCategories.length === 0) {
+        event.preventDefault();
+        const formError = document.getElementsByClassName("form-error category")[0];
+        formError.classList.add("visible");
+        formError.textContent = '카테고리를 선택해주세요';
+    }
+}
+
+/**
+ * 이미지 미리보기 및 삭제 동작
+ */
+function previewImage() {
+    const preview = document.getElementById("preview-image");
+    const thumbnailInput = document.getElementById("thumbnail");
+    const imgRemoveButton = document.querySelector(".img-remove-button");
+
+    thumbnailInput.addEventListener("change", () => {
+        const file = thumbnailInput.files[0];
+        if (file) addPreviewImage(preview, file, imgRemoveButton);
+    });
+    removePreviewImage(imgRemoveButton, preview, thumbnailInput);
+}
+
+/**
+ * 이미지 미리보기
+ */
+function addPreviewImage(preview, file, removeButton) {
+    preview.classList.add("visible");
+    removeButton.classList.add("visible");
+    const reader = new FileReader();
+    reader.onload = function (event) {
+        preview.src = event.target.result;
+    };
+    reader.readAsDataURL(file);
+}
+
+/**
+ * 이미지 미리보기 제거
+ */
+function removePreviewImage(removeButton, preview, input) {
+    removeButton.addEventListener("click", () => {
+        preview.src = "#";
+        preview.classList.remove("visible");
+        input.value = "";
+        removeButton.classList.remove("visible");
+    });
+}
+
+/**
+ * DOMContentLoaded 이벤트 리스너
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    initializeEditor();
+    validateForm();
+    previewImage();
+});

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -1,12 +1,32 @@
 import initializeEditor from "./portfolio-write-ckeditor5.js";
 
 /**
+ * 에디터 이미지 src를 input에 추가
+ */
+// Todo : 로직 수정
+function addImageSrcToBody() {
+    const imageListBox = document.getElementById("image-list-box");
+    const editor = document.querySelector(".ck-content")[0];
+    const images = editor.querySelectorAll("img");
+
+    images.forEach(el => {
+        const input = document.createElement("input");
+        input.setAttribute("type", "hidden");
+        input.setAttribute("name", "images");
+        input.setAttribute("value", el.src);
+        imageListBox.appendChild(input);
+    });
+}
+
+/**
  * form 검증
  */
 function validateForm() {
     const form = document.getElementById("write-form");
     form.addEventListener("submit", (event) => {
         validateCategory(event);
+        validImageCount(event);
+        addImageSrcToBody();
     });
 }
 
@@ -21,6 +41,20 @@ function validateCategory(event) {
         const formError = document.getElementsByClassName("form-error category")[0];
         formError.classList.add("visible");
         formError.textContent = '카테고리를 선택해주세요';
+    }
+}
+
+/**
+ * CKEditor 이미지 개수 제한
+ */
+// Todo : 로직 수정
+function validImageCount(event) {
+    const editor = document.querySelector(".ck-content")[0];
+    const images = editor.querySelectorAll("img");
+    const error = document.getElementsByClassName("form-error editor")[0];
+    if (images.length > 50) {
+        event.preventDefault();
+        error.textContent = "이미지는 최대 50개까지만 첨부할 수 있습니다";
     }
 }
 

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -1,24 +1,6 @@
 import initializeEditor from "./portfolio-write-ckeditor5.js";
 
 /**
- * 에디터 이미지 src를 input에 추가
- */
-// Todo : 로직 수정
-function addImageSrcToBody() {
-    const imageListBox = document.getElementById("image-list-box");
-    const editor = document.querySelector(".ck-content")[0];
-    const images = editor.querySelectorAll("img");
-
-    images.forEach(el => {
-        const input = document.createElement("input");
-        input.setAttribute("type", "hidden");
-        input.setAttribute("name", "images");
-        input.setAttribute("value", el.src);
-        imageListBox.appendChild(input);
-    });
-}
-
-/**
  * form 검증
  */
 function validateForm() {
@@ -26,7 +8,6 @@ function validateForm() {
     form.addEventListener("submit", (event) => {
         validateCategory(event);
         validImageCount(event);
-        addImageSrcToBody();
     });
 }
 
@@ -47,10 +28,9 @@ function validateCategory(event) {
 /**
  * CKEditor 이미지 개수 제한
  */
-// Todo : 로직 수정
 function validImageCount(event) {
-    const editor = document.querySelector(".ck-content")[0];
-    const images = editor.querySelectorAll("img");
+    const imageList = document.querySelector("#image-list-box");
+    const images = imageList.querySelectorAll("input");
     const error = document.getElementsByClassName("form-error editor")[0];
     if (images.length > 50) {
         event.preventDefault();

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -6,6 +6,7 @@ import initializeEditor from "./portfolio-write-ckeditor5.js";
 function validateForm() {
     const form = document.getElementById("write-form");
     form.addEventListener("submit", (event) => {
+        validDate(event);
         validateCategory(event);
         validImageCount(event);
     });
@@ -17,9 +18,9 @@ function validateForm() {
 function validateCategory(event) {
     const categories = document.querySelectorAll(".category-list input[type='checkbox']");
     const checkedCategories = Array.from(categories).filter(category => category.checked);
+    const formError = document.getElementsByClassName("form-error category")[0];
     if (checkedCategories.length === 0) {
         event.preventDefault();
-        const formError = document.getElementsByClassName("form-error category")[0];
         formError.classList.add("visible");
         formError.textContent = '카테고리를 선택해주세요';
     }
@@ -31,10 +32,25 @@ function validateCategory(event) {
 function validImageCount(event) {
     const imageList = document.querySelector("#image-list-box");
     const images = imageList.querySelectorAll("input");
-    const error = document.getElementsByClassName("form-error editor")[0];
+    const formError = document.getElementsByClassName("form-error editor")[0];
     if (images.length > 50) {
         event.preventDefault();
-        error.textContent = "이미지는 최대 50개까지만 첨부할 수 있습니다";
+        formError.classList.add("visible");
+        formError.textContent = "이미지는 최대 50개까지만 첨부할 수 있습니다";
+    }
+}
+
+/**
+ * 날짜 검증
+ */
+function validDate(event) {
+    const startDate = document.getElementById("start-date").value;
+    const endDate = document.getElementById("end-date").value;
+    const formError = document.getElementsByClassName("form-error date")[0];
+    if (startDate > endDate) {
+        event.preventDefault();
+        formError.classList.add("visible");
+        formError.textContent = "프로젝트 기간이 잘못되었습니다.";
     }
 }
 

--- a/src/main/resources/static/js/portfolio/portfolio-write.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write.js
@@ -136,7 +136,12 @@ function addTemplate() {
                     const key = radio.value;
                     const data = templateData[key];
                     const headings = data.headings;
-                    addHeadingsToEditor(headings);
+                    if (key <= 2) {
+                        // 만들어둔 템플릿 추가
+                        addHeadingsToEditor(headings);
+                    } else if (key === 4) {
+                        // Todo: AI 추천 템플릿 추가
+                    }
                 }
             });
         });
@@ -146,15 +151,19 @@ function addTemplate() {
         
         if (window.editor) {
             const editor = window.editor;
-    
-            editor.model.change(writer => {
-                const insertPosition = editor.model.document.selection.getLastPosition();
-                console.log(insertPosition)
 
+            editor.model.change(writer => {
+                // 에디터 요소 중 마지막 요소 위치 가져오기
+                const root = editor.model.document.getRoot();
+                const children = Array.from(root.getChildren());
+                const lastChild = children[children.length - 1];
+                const position = writer.createPositionAfter(lastChild);
+
+                // 템플릿으로 지정한 heading 추가
                 headings.forEach(heading => {
                     const tagElement = writer.createElement(heading.tagType);
                     writer.insertText(heading.value, tagElement);
-                    writer.append(tagElement, insertPosition);
+                    writer.append(tagElement, position);
                 });
             });
         } else {

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -123,21 +123,21 @@
             </form>
         </section>
         <aside class="template-select">
-            <h2>템플릿 선택</h2>
+            <h2>템플릿 추가</h2>
             <ul class="template-list">
                 <li>
                     <div class="radio-input-group">
-                        <input type="radio" id="template-custom" name="template">
+                        <input type="radio" id="template-custom" name="template" checked>
                         <label>자유 템플릿</label>
                     </div>
-                    <span>자유 형식 템플릿</span>
+                    <span>자유 형식 포트폴리오 템플릿</span>
                 </li>
                 <li>
                     <div class="radio-input-group">
                         <input type="radio" id="template-ai" name="template">
                         <label>AI 추천 템플릿</label>
                     </div>
-                    <span>Alan AI가 추천하는 템플릿</span>
+                    <span>Alan AI가 추천하는 포트폴리오 템플릿</span>
                 </li>
             </ul>
         </aside>

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -45,9 +45,11 @@
                     <input type="date" id="end-date" th:field="*{endDate}">
                     <div th:if="${#fields.hasErrors('startDate')}" class="error-box">
                         <span th:errors="*{startDate}" class="form-error"></span>
-                    </div>
-                    <div th:if="${#fields.hasErrors('endDate')}" class="error-box">
                         <span th:errors="*{endDate}" class="form-error"></span>
+
+                    </div>
+                    <div>
+                        <span class="form-error date"></span>
                     </div>
                 </div>
                 <div class="input-group category-input-group">

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -22,6 +22,7 @@
                 <span>*은 필수 입력 항목입니다.</span>
             </div>
             <form th:action="@{/portfolio/new}" method="post" id="write-form"
+                  enctype="multipart/form-data"
                   th:object="${writeDto}">
                 <div class="input-group">
                     <label for="title" class="group-label">
@@ -31,6 +32,9 @@
                     <input type="text" id="title" th:field="*{title}"
                     placeholder="포트폴리오 제목을 작성해주세요"
                     maxlength="200" required>
+                    <div th:if="${#fields.hasErrors('title')}" class="error-box">
+                        <span th:errors="*{title}" class="form-error"></span>
+                    </div>
                 </div>
                 <div class="input-group">
                     <label for="start-date" class="group-label">
@@ -39,6 +43,12 @@
                     <input type="date" id="start-date" th:field="*{startDate}">
                     <span>-</span>
                     <input type="date" id="end-date" th:field="*{endDate}">
+                    <div th:if="${#fields.hasErrors('startDate')}" class="error-box">
+                        <span th:errors="*{startDate}" class="form-error"></span>
+                    </div>
+                    <div th:if="${#fields.hasErrors('endDate')}" class="error-box">
+                        <span th:errors="*{endDate}" class="form-error"></span>
+                    </div>
                 </div>
                 <div class="input-group category-input-group">
                     <div class="group-label">
@@ -49,13 +59,16 @@
                         <ul class="category-list">
                             <li th:each="category : ${categories}">
                                 <input type="checkbox" th:id="'category ' + ${category.categoryIdx}"
-                                       th:field="*{categories}" th:value="${category.categoryIdx}"
-                                       required>
+                                       th:field="*{categories}" th:value="${category.categoryIdx}">
                                 <label th:for="'category ' + ${category.categoryIdx}"
                                        th:text="${category.nameKo}">카테고리 이름</label>
                             </li>
                         </ul>
                         <span>카테고리는 중복 선택할 수 있습니다.</span>
+                        <span class="form-error category"></span>
+                        <div th:if="${#fields.hasErrors('categories')}" class="error-box">
+                            <span th:errors="*{categories}" class="form-error"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="input-group image-input-group">
@@ -66,11 +79,14 @@
                     <input type="file" id="thumbnail" accept="image/*" th:field="*{thumbnail}">
                     <div class="image-preview">
                         <div class="preview-box">
-                            <img alt="업로드한 이미지 미리보기">
+                            <img id="preview-image" alt="업로드한 이미지 미리보기">
                             <button type="button" class="img-remove-button">
                                 <img th:src="@{/assets/icon/x-lg.svg}" alt="취소 버튼">
                             </button>
                         </div>
+                    </div>
+                    <div th:if="${#fields.hasErrors('thumbnail')}" class="error-box">
+                        <span th:errors="*{thumbnail}" class="form-error"></span>
                     </div>
                 </div>
                 <div class="input-group textarea-input-group">
@@ -84,11 +100,12 @@
                             id="editor-container"
                         >
                             <div class="editor-container__editor">
-                                <textarea id="editor" th:field="*{description}"
-                                          required
-                                ></textarea>
+                                <textarea id="editor" th:field="*{description}"></textarea>
                             </div>
                         </div>
+                    </div>
+                    <div th:if="${#fields.hasErrors('description')}" class="error-box">
+                        <span th:errors="*{description}" class="form-error"></span>
                     </div>
                 </div>
                 <div class="button-wrap">
@@ -144,6 +161,6 @@
     }
 }
 </script>
-<script type="module" th:src="@{/js/portfolio/portfolio-write-ckeditor5.js}"></script>
+<script type="module" th:src="@{/js/portfolio/portfolio-write.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -94,6 +94,9 @@
                         <span>상세 설명</span>
                         <span class="required-mark">*</span>
                     </label>
+                    <div class="error-box">
+                        <span class="form-error editor"></span>
+                    </div>
                     <div class="main-container">
                         <div
                             class="editor-container editor-container_classic-editor editor-container_include-style editor-container_include-fullscreen"
@@ -103,6 +106,7 @@
                                 <textarea id="editor" th:field="*{description}"></textarea>
                             </div>
                         </div>
+                        <div id="image-list-box"></div>
                     </div>
                     <div th:if="${#fields.hasErrors('description')}" class="error-box">
                         <span th:errors="*{description}" class="form-error"></span>

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -127,20 +127,6 @@
             <ul class="template-list">
                 <li>
                     <div class="radio-input-group">
-                        <input type="radio" id="template-1" name="template">
-                        <label>템플릿 1</label>
-                    </div>
-                    <span>프로젝트 설명을 위한 기본 템플릿 1</span>
-                </li>
-                <li>
-                    <div class="radio-input-group">
-                        <input type="radio" id="template-2" name="template">
-                        <label>템플릿 2</label>
-                    </div>
-                    <span>프로젝트 설명을 위한 기본 템플릿 1</span>
-                </li>
-                <li>
-                    <div class="radio-input-group">
                         <input type="radio" id="template-custom" name="template">
                         <label>자유 템플릿</label>
                     </div>


### PR DESCRIPTION
## ✍️ 변경 요약 (Summary of Changes)
- 포트폴리오 작성 동작 추가
- 데이터베이스에 포트폴리오 데이터 추가
- CKEditor를 적용한 마크다운 형식의 데이터 추가
- CKEditor를 사용한 이미지 추가 동작 적용
  - 이미지 개수 및 사이즈 제한은 미적용
- 이미지 파일 추가 동작 적용

## 🧠 변경 이유 (Motivation / Why)
- 포트폴리오 작성 기능 구현
- CKEditor를 사용한 다양한 입력 형식 및 스타일 제공
- AWS S3 이미지 업로드 기능 제공
- 연관된 이슈 : #21, #24 

## ✅ 리뷰어가 확인해야 할 사항 (Review Guidance)
- 파일 업로드 기능 구조