### PR TITLE
fix: 소셜 로그인 오류 해결 1. 소셜 로그인으로 회원가입 한 사용자가 다시 로그인 하는 경우 오류 발생 -> 이메일로 기존 사용자 조회 후 로컬 회원이면 소셜로그인 차단, 기존 소셜 회원이면 로그인 처리 2. login 페이지에서 오류 메세지 소셜 로그인과 로컬 로그인을 분리

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
 			<type>pom</type>
 		</dependency>
 		<dependency>
+			<groupId>com.github.downgoon</groupId>
+			<artifactId>MarvinPlugins</artifactId>
+			<version>1.5.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.commonmark</groupId>
 			<artifactId>commonmark</artifactId>
 			<version>0.25.1</version>
@@ -160,7 +165,6 @@
 						<exclude>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.38</version>
 						</exclude>
 					</excludes>
 				</configuration>

--- a/src/main/java/io/github/sunday/devfolio/controller/OAuth2Controller.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/OAuth2Controller.java
@@ -24,16 +24,23 @@ public class OAuth2Controller {
         String name = oauthUser.getAttribute("name");
         String providerId = oauthUser.getAttribute("sub");
 
-        // 이미 해당 이메일로 가입된 사용자가 있으면 로그인 차단
+        // 이메일로 기존 사용자 조회
         User existingUser = userService.findByEmail(email);
+
         if (existingUser != null) {
-            return "redirect:/login?error=email";
+            if (existingUser.getOauthProvider() == null) {
+                // 기존 로컬 회원이면 소셜 로그인 차단
+                return "redirect:/login?error=email";
+            } else {
+                // 기존 소셜 회원이면 로그인 처리
+                return "redirect:/main";
+            }
         }
 
-        // 닉네임 자동 생성
+        // 신규 소셜 회원이면 닉네임 자동 생성
         String nickname = userService.generateValidNickname(name);
 
-        // 아이디 자동 생성
+        // 신규 소셜 회원이면 아이디 자동 생성
         String generatedId = userService.generateUserId(email);
 
         User newUser = new User(generatedId, email, nickname, null, providerId, AuthProvider.GOOGLE);

--- a/src/main/java/io/github/sunday/devfolio/interceptor/LoginUserInterceptor.java
+++ b/src/main/java/io/github/sunday/devfolio/interceptor/LoginUserInterceptor.java
@@ -23,7 +23,7 @@ public class LoginUserInterceptor implements HandlerInterceptor {
         HttpSession session = request.getSession();
 
         // 이미 세션에 저장된 경우 스킵
-        if (session.getAttribute("loginUserId") != null) {
+        if (session.getAttribute("loginUserIdx") != null) {
             return true;
         }
 
@@ -44,9 +44,6 @@ public class LoginUserInterceptor implements HandlerInterceptor {
 
             if (user != null) {
                 session.setAttribute("loginUserIdx", user.getUserIdx());
-                session.setAttribute("loginId", user.getLoginId());
-                session.setAttribute("loginNickname", user.getNickname());
-                session.setAttribute("loginEmail", user.getEmail());
             }
         }
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -113,11 +113,11 @@
       회원가입이 완료되었습니다. 로그인해 주세요.
     </div>
 
-    <div th:if="${param.error} == 'email'" class="msg error">
+    <div th:if="${param.error} eq 'email'" class="msg error">
       이미 사용 중인 이메일입니다. 기존 계정으로 로그인해 주세요.
     </div>
 
-    <div th:if="${param.error}" class="msg error">아이디 또는 비밀번호가 잘못되었습니다.</div>
+    <div th:if="${param.error} eq 'login'" class="msg error">아이디 또는 비밀번호가 잘못되었습니다.</div>
   </div>
 
   <form method="post" th:action="@{/login}">


### PR DESCRIPTION
fix: 소셜 로그인 오류 해결

## ✍️ 변경 요약 (Summary of Changes)
- 기존 소셜 회원이 다시 로그인 한 경우 로그인 실패하는 문제 해결

## 🧠 변경 이유 (Motivation / Why)
- 기존에는 모든 로그인 시 이미 사용즁인 이메일이면 모두 로그인 실패 처리 


