### PR TITLE
feat(portfolio): Alan AI에 템플릿 요청 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>com.google.genai</groupId>-->
-<!--			<artifactId>google-genai</artifactId>-->
-<!--			<version>1.9.0</version>-->
-<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>com.google.genai</groupId>-->
+<!--			<artifactId>google-genai</artifactId>-->
+<!--			<version>1.9.0</version>-->
+<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,10 @@
 			<version>5.5</version>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/io/github/sunday/devfolio/DTO/common/AlanResponseDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/common/AlanResponseDto.java
@@ -1,0 +1,52 @@
+package io.github.sunday.devfolio.dto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Alan AI 답변을 담는 Dto
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AlanResponseDto {
+    /**
+     * 동작
+     */
+    private Action action;
+
+    /**
+     * 답변 내용
+     */
+    private String content;
+
+    public class Action {
+        /**
+         * 동작 타입
+         */
+        protected String name;
+
+        /**
+         * AI 응답 내용으로 추정되는 데이터
+         */
+        protected String speak;
+
+        public Action() {}
+
+        public Action(String name, String speak) {
+            this.name = name;
+            this.speak = speak;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getSpeak() {
+            return speak;
+        }
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateDto.java
@@ -1,5 +1,6 @@
 package io.github.sunday.devfolio.dto.portfolio;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 /**
@@ -10,6 +11,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PortfolioTemplateDto {
 
     /**

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateDto.java
@@ -1,0 +1,24 @@
+package io.github.sunday.devfolio.dto.portfolio;
+
+import lombok.*;
+
+/**
+ * Alan Ai에게 추천받은 포트폴리오 템플릿 응답용 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioTemplateDto {
+
+    /**
+     * HTML 태그 타입
+     */
+    private String tagType;
+
+    /**
+     * 목차 내용
+     */
+    private String value;
+}

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioTemplateRequestDto.java
@@ -1,0 +1,22 @@
+package io.github.sunday.devfolio.dto.portfolio;
+
+import io.github.sunday.devfolio.annotation.portfolio.PortfolioCategoryValid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 포트폴리오 템플릿 요청 Dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioTemplateRequestDto {
+    /**
+     * 포트폴리오 카테고리 타입
+     */
+    @NotBlank(message = "카테고리를 입력해주세요")
+    @PortfolioCategoryValid
+    private String type;
+}

--- a/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * HTTP 요청용 RestClient
@@ -29,5 +30,13 @@ public class RestClientConfig {
                 .defaultHeader("Content-Type", "application/json")
                 .defaultHeader("Accept", "application/json")
                 .build();
+    }
+
+    /**
+     * Delete 요청용 RestTemplate
+     */
+    @Bean
+    public RestTemplate alanRestTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
@@ -3,6 +3,7 @@ package io.github.sunday.devfolio.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -19,15 +20,10 @@ public class RestClientConfig {
             @Value("${alan.api.url.base}") String baseUrl
     ) {
         return RestClient.builder()
+                .requestFactory(new SimpleClientHttpRequestFactory())
                 .baseUrl(baseUrl)
                 .defaultHeader("Content-Type", "application/json")
                 .defaultHeader("Accept", "application/json")
                 .build();
     }
-
-//    @Bean
-//    public RestClient geminiClient(@Value("${gemini.api-key}") String apiKey) {
-//        return RestClient.builder()
-//                .build();
-//    }
 }

--- a/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
@@ -3,7 +3,7 @@ package io.github.sunday.devfolio.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -19,8 +19,12 @@ public class RestClientConfig {
     public RestClient alanClient(
             @Value("${alan.api.url.base}") String baseUrl
     ) {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(100);
+        factory.setConnectionRequestTimeout(70);
+
         return RestClient.builder()
-                .requestFactory(new SimpleClientHttpRequestFactory())
+                .requestFactory(factory)
                 .baseUrl(baseUrl)
                 .defaultHeader("Content-Type", "application/json")
                 .defaultHeader("Accept", "application/json")

--- a/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/RestClientConfig.java
@@ -1,0 +1,33 @@
+package io.github.sunday.devfolio.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * HTTP 요청용 RestClient
+ */
+@Configuration
+public class RestClientConfig {
+
+    /**
+     * Alan AI 요청용 RestClient 빈 등록 
+     */
+    @Bean
+    public RestClient alanClient(
+            @Value("${alan.api.url.base}") String baseUrl
+    ) {
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Content-Type", "application/json")
+                .defaultHeader("Accept", "application/json")
+                .build();
+    }
+
+//    @Bean
+//    public RestClient geminiClient(@Value("${gemini.api-key}") String apiKey) {
+//        return RestClient.builder()
+//                .build();
+//    }
+}

--- a/src/main/java/io/github/sunday/devfolio/config/SecurityConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/main", "/signup", "/login", "/email/**", "/check/**", "/portfolio/**", "/portfolio**", "/error").permitAll()
-                        .requestMatchers("/css/**", "/js/**", "/assets/**", "/ckeditor5/**").permitAll()
+                        .requestMatchers("/css/**", "/js/**", "/assets/**", "/ckeditor5/**", "/prompts/**").permitAll()
                         .requestMatchers("/api/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/io/github/sunday/devfolio/config/WebConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/WebConfig.java
@@ -20,6 +20,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginUserInterceptor(userService))
                 .addPathPatterns("/**")
-                .excludePathPatterns("/css/**", "/js/**", "/assets/**");
+                .excludePathPatterns("/css/**", "/js/**", "/assets/**", "/ckeditor5/**");
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/config/WebConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/WebConfig.java
@@ -20,6 +20,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginUserInterceptor(userService))
                 .addPathPatterns("/**")
-                .excludePathPatterns("/css/**", "/js/**", "/assets/**", "/ckeditor5/**");
+                .excludePathPatterns("/css/**", "/js/**", "/assets/**", "/ckeditor5/**", "/prompts/**");
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AIController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AIController.java
@@ -1,12 +1,11 @@
 package io.github.sunday.devfolio.controller.common;
 
+import io.github.sunday.devfolio.dto.portfolio.PortfolioTemplateRequestDto;
 import io.github.sunday.devfolio.service.common.AIService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * AI 서비스 요청용 컨트롤러
@@ -22,10 +21,10 @@ public class AIController {
      */
     @GetMapping("/portfolio-template")
     public ResponseEntity<?> getPortfolioTemplate(
-            @RequestParam String type
+            @Valid @ModelAttribute PortfolioTemplateRequestDto requestDto
     ) {
         try {
-            return aiService.getPortfolioTemplate(type);
+            return aiService.getPortfolioTemplate(requestDto.getType());
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().body("내부 서버 에러가 발생했습니다.");

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AIController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AIController.java
@@ -1,6 +1,6 @@
 package io.github.sunday.devfolio.controller.common;
 
-import io.github.sunday.devfolio.service.common.AiService;
+import io.github.sunday.devfolio.service.common.AIService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/ai")
 @RequiredArgsConstructor
-public class AiController {
-    private final AiService aiService;
+public class AIController {
+    private final AIService aiService;
 
     /**
      * Alan AI로 포트폴리오 작성 템플릿 요청하기

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 /**
  * AI 서비스 요청용 컨트롤러
  */
@@ -24,7 +26,13 @@ public class AiController {
     public ResponseEntity<String> getPortfolioTemplate(
             @RequestParam String type
     ) {
-        String response = aiService.getPortfolioTemplate(type);
-        return ResponseEntity.ok(response);
+        try {
+            String response = aiService.getPortfolioTemplate(type);
+            aiService.resetState();
+            return ResponseEntity.ok(response);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body("내부 서버 에러가 발생했습니다.");
+        }
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
@@ -2,6 +2,7 @@ package io.github.sunday.devfolio.controller.common;
 
 import io.github.sunday.devfolio.service.common.AiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +29,10 @@ public class AiController {
     ) {
         try {
             String response = aiService.getPortfolioTemplate(type);
-            //aiService.resetState();
+            ResponseEntity<?> deleteResponse = aiService.resetState();
+            if (!deleteResponse.getStatusCode().equals(HttpStatus.OK)) {
+                System.out.println(deleteResponse.toString());
+            }
             return ResponseEntity.ok(response);
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
@@ -28,7 +28,7 @@ public class AiController {
     ) {
         try {
             String response = aiService.getPortfolioTemplate(type);
-            aiService.resetState();
+            //aiService.resetState();
             return ResponseEntity.ok(response);
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
@@ -2,14 +2,11 @@ package io.github.sunday.devfolio.controller.common;
 
 import io.github.sunday.devfolio.service.common.AiService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.IOException;
 
 /**
  * AI 서비스 요청용 컨트롤러
@@ -24,17 +21,12 @@ public class AiController {
      * Alan AI로 포트폴리오 작성 템플릿 요청하기
      */
     @GetMapping("/portfolio-template")
-    public ResponseEntity<String> getPortfolioTemplate(
+    public ResponseEntity<?> getPortfolioTemplate(
             @RequestParam String type
     ) {
         try {
-            String response = aiService.getPortfolioTemplate(type);
-            ResponseEntity<?> deleteResponse = aiService.resetState();
-            if (!deleteResponse.getStatusCode().equals(HttpStatus.OK)) {
-                System.out.println(deleteResponse.toString());
-            }
-            return ResponseEntity.ok(response);
-        } catch (IOException e) {
+            return aiService.getPortfolioTemplate(type);
+        } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().body("내부 서버 에러가 발생했습니다.");
         }

--- a/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/common/AiController.java
@@ -1,0 +1,30 @@
+package io.github.sunday.devfolio.controller.common;
+
+import io.github.sunday.devfolio.service.common.AiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * AI 서비스 요청용 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class AiController {
+    private final AiService aiService;
+
+    /**
+     * Alan AI로 포트폴리오 작성 템플릿 요청하기
+     */
+    @GetMapping("/portfolio-template")
+    public ResponseEntity<String> getPortfolioTemplate(
+            @RequestParam String type
+    ) {
+        String response = aiService.getPortfolioTemplate(type);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/common/AIService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/AIService.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
  */
 @Service
 @RequiredArgsConstructor
-public class AiService {
+public class AIService {
 
     @Value("${alan.api.url.base}")
     private String baseUrl;

--- a/src/main/java/io/github/sunday/devfolio/service/common/AIService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/AIService.java
@@ -91,16 +91,16 @@ public class AIService {
         if (type == null || type.isEmpty()) return ResponseEntity.badRequest().body("카테고리 타입을 입력해주세요");
 
         try {
+            // Alan AI state 초기화
+            ResponseEntity<?> deleteResponse = resetState();
+            if (!deleteResponse.getStatusCode().equals(HttpStatus.OK)) {
+                System.out.println(deleteResponse.toString());
+            }
+
             // Alan AI에 요청 전송
             AlanResponseDto response = sendAIRequest(type);
 
             if (response != null && response.getContent() != null && !response.getContent().isEmpty()) {
-                // Alan AI state 초기화
-                ResponseEntity<?> deleteResponse = resetState();
-                if (!deleteResponse.getStatusCode().equals(HttpStatus.OK)) {
-                    System.out.println(deleteResponse.toString());
-                }
-                
                 // 응답을 JSON 형태로 가공 후 DTO 형식에 맞게 변환
                 JsonNode jsonArray = StringExtractUtils.extractJsonArray(response);
                 List<PortfolioTemplateDto> templates = StringExtractUtils.parseToTemplateResponse(jsonArray);

--- a/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
@@ -1,0 +1,48 @@
+package io.github.sunday.devfolio.service.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * AI 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    @Value("${alan.api.url.question}")
+    private String alanUrlQuestion;
+
+    @Value("${alan.api.url.reset}")
+    private String alanUrlReset;
+
+    @Value("${alan.api.key}")
+    private String alanApiKey;
+
+    private final RestClient alanClient;
+
+    /**
+     * 포트폴리오 템플릿 추천 받기 
+     */
+    public String getPortfolioTemplate(String type) {
+        return alanClient.get()
+                .uri(buildRequestUrl(type))
+                .retrieve()
+                .body(String.class);
+    }
+
+    /**
+     * Alan AI 요청용 URL 생성
+     */
+    private String buildRequestUrl(String type) {
+        String content = "개발자 프로젝트에 대한 포트폴리오를 작성하고 있어." + type + " 프로젝트를 진행했을 때 자주 사용하는 목차를 추천해줘.";
+        return UriComponentsBuilder.fromPath(alanUrlQuestion)
+                .queryParam("content", content)
+                .queryParam("client_id", alanApiKey)
+                .encode()
+                .build().toUriString();
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
@@ -3,12 +3,17 @@ package io.github.sunday.devfolio.service.common;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +25,9 @@ import java.nio.file.Path;
 @RequiredArgsConstructor
 public class AiService {
 
+    @Value("${alan.api.url.base}")
+    private String baseUrl;
+
     @Value("${alan.api.url.question}")
     private String alanUrlQuestion;
 
@@ -30,6 +38,7 @@ public class AiService {
     private String alanApiKey;
 
     private final RestClient alanClient;
+    private final RestTemplate alanRestTemplate;
 
     /**
      * 포트폴리오 템플릿 추천 받기 
@@ -44,11 +53,17 @@ public class AiService {
     /**
      * 상태 초기화
      */
-    public ResponseEntity<Void> resetState() {
-        return alanClient.delete()
-                .uri(alanUrlReset)
-                .retrieve()
-                .toBodilessEntity();
+    public ResponseEntity<?> resetState() {
+        String url = baseUrl + alanUrlReset;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        headers.set("Accept", "application/json");
+
+        String body = String.format("{\"client_id\": \"%s\"}", alanApiKey);
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
+
+        return alanRestTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
     }
 
     /**

--- a/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/AiService.java
@@ -46,7 +46,7 @@ public class AiService {
      */
     public ResponseEntity<Void> resetState() {
         return alanClient.delete()
-                .uri(buildAlanResetUrl())
+                .uri(alanUrlReset)
                 .retrieve()
                 .toBodilessEntity();
     }
@@ -61,16 +61,6 @@ public class AiService {
         String prompt = String.format(convert, type);
         return UriComponentsBuilder.fromPath(alanUrlQuestion)
                 .queryParam("content", prompt)
-                .queryParam("client_id", alanApiKey)
-                .encode()
-                .build().toUriString();
-    }
-
-    /**
-     * Alan AI 리셋용 URL 생성
-     */
-    private String buildAlanResetUrl() {
-        return UriComponentsBuilder.fromPath(alanUrlReset)
                 .queryParam("client_id", alanApiKey)
                 .encode()
                 .build().toUriString();

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioCategoryService.java
@@ -44,12 +44,21 @@ public class PortfolioCategoryService {
     }
 
     /**
-     * 카테고리 이름으로 존재하는 카테고리인지 검증
+     * 카테고리 id로 존재하는 카테고리인지 검증
      */
     public boolean exists(Long categoryIdx) {
         if (categoryIdx == null) return true;
         return cachedCategories.stream()
                 .anyMatch(category -> category.getCategoryIdx().equals(categoryIdx));
+    }
+
+    /**
+     * 카테고리 이름으로 존재하는 카테고리인지 검증
+     */
+    public boolean existsByName(String name) {
+        if (name == null || name.isEmpty()) return false;
+        return cachedCategories.stream()
+                .anyMatch(category -> category.getNameKo().equals(name));
     }
 
     /**

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioLikeService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioLikeService.java
@@ -56,7 +56,11 @@ public class PortfolioLikeService {
                 .likedAt(ZonedDateTime.now())
                 .build();
         PortfolioLike saved = portfolioLikeRepository.save(portfolioLike);
-
+        
+        // 좋아요 카운트 변경
+        portfolio.setLikeCount(portfolio.getLikeCount()+1);
+        portfolioRepository.save(portfolio);
+        
         if (saved == null) {
             throw new Exception("좋아요 추가 중에 에러가 발생했습니다");
         }
@@ -73,6 +77,11 @@ public class PortfolioLikeService {
         validateNotOwner(user, portfolio);
 
         PortfolioLike target = portfolioLikeRepository.findByUserAndPortfolio(user, portfolio).orElse(null);
+
+        // 좋아요 카운트 변경
+        Integer likeCount = portfolio.getLikeCount() > 0 ? portfolio.getLikeCount() - 1 : 0;
+        portfolio.setLikeCount(likeCount);
+        portfolioRepository.save(portfolio);
 
         if (target != null) {
             portfolioLikeRepository.delete(target);

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/portfolio/PortfolioService.java
@@ -126,6 +126,10 @@ public class PortfolioService {
         String createdAt = portfolio.getCreatedAt() != null ? portfolio.getCreatedAt().format(dateTimeformatter) : null;
         String updatedAt = portfolio.getUpdatedAt() != null ? portfolio.getUpdatedAt().format(dateTimeformatter) : null;
 
+        // 조회수 올리기
+        portfolio.setViews(portfolio.getViews()+1);
+        portfolioRepository.save(portfolio);
+
         return PortfolioDetailDto.builder()
                 .portfolioIdx(portfolioIdx)
                 .title(portfolio.getTitle())

--- a/src/main/java/io/github/sunday/devfolio/utils/StringExtractUtils.java
+++ b/src/main/java/io/github/sunday/devfolio/utils/StringExtractUtils.java
@@ -1,0 +1,53 @@
+package io.github.sunday.devfolio.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.sunday.devfolio.dto.common.AlanResponseDto;
+import io.github.sunday.devfolio.dto.portfolio.PortfolioTemplateDto;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Alan AI의 Content 내의 JSON을 가공하는 유틸 클래스
+ */
+public class StringExtractUtils {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Alan AI에서 응답 내용 중 JSON 추출하기
+     */
+    public static JsonNode extractJsonArray(AlanResponseDto response) throws Exception {
+        if (response == null || response.getContent() == null || response.getContent().isEmpty()) {
+            throw new IllegalArgumentException("응답 데이터나 내용이 비어있습니다");
+        }
+
+        // content 문자열 가져오기
+        String content = response.getContent();
+
+        // ```json ... ``` 구간만 추출
+        Pattern pattern = Pattern.compile("```json\\s*(.*?)\\s*```", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(content);
+
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("content에 json 블록이 없습니다.");
+        }
+
+        String jsonPart = matcher.group(1); // ```json 과 ``` 사이 문자열
+
+        // JSON 파싱
+        return mapper.readTree(jsonPart);
+    }
+
+    /**
+     * 추출한 JSON을 포트폴리오 템플릿 형식으로 변환하기
+     */
+    public static List<PortfolioTemplateDto> parseToTemplateResponse(JsonNode jsonNode) {
+        if (jsonNode == null || !jsonNode.isArray()) {
+            throw new IllegalArgumentException("JSON 데이터가 배열 형식이 아닙니다.");
+        }
+        return mapper.convertValue(jsonNode, new TypeReference<List<PortfolioTemplateDto>>() {});
+    }
+}

--- a/src/main/java/io/github/sunday/devfolio/validator/portfolio/PortfolioCategoryValidator.java
+++ b/src/main/java/io/github/sunday/devfolio/validator/portfolio/PortfolioCategoryValidator.java
@@ -7,6 +7,7 @@ import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -25,16 +26,28 @@ public class PortfolioCategoryValidator implements ConstraintValidator<Portfolio
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         if (value == null) return true;
 
+        // 포트폴리오 id로 요청이 들어오는 경우
         if (value instanceof Long id) {
             return portfolioCategoryService.exists(id);
         }
 
+        // 포트폴리오 id 리스트로 요청이 들어오는 경우
         if (value instanceof List<?> list) {
             return list.stream()
                     .filter(Long.class::isInstance)
                     .map(Long.class::cast)
                     .allMatch(portfolioCategoryService::exists);
         }
+
+        // 포트폴리오 String으로 요청이 들어오는 경우
+        if (value instanceof String name) {
+            if (name.isEmpty()) return false;
+
+            String[] categories = name.split("\\s*,\\s*");
+            return Arrays.stream(categories)
+                    .allMatch(categoryName -> portfolioCategoryService.existsByName(categoryName));
+        }
+
         return false;
     }
 }

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -48,3 +48,11 @@ aws:
   region: ${AWS_REGION}
   s3:
     bucket-name: ${AWS_S3_BUCKET_NAME}
+
+alan:
+  api:
+    url:
+      base: ${ALAN_URL_BASE}
+      question: ${ALAN_URL_QUESTION}
+      reset: ${ALAN_URL_RESET}
+    key: ${ALAN_API_KEY}

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -42,3 +42,11 @@ aws:
   region: ${AWS_REGION}
   s3:
     bucket-name: ${AWS_S3_BUCKET_NAME}
+
+alan:
+  api:
+    url:
+      base: ${ALAN_URL_BASE}
+      question: ${ALAN_URL_QUESTION}
+      reset: ${ALAN_URL_RESET}
+    key: ${ALAN_API_KEY}

--- a/src/main/resources/static/css/common/styles.css
+++ b/src/main/resources/static/css/common/styles.css
@@ -148,3 +148,31 @@ input:autofill:active {
 .ck-content .button--black {
 	background-color: #141517;
 }
+
+/* loading spinner */
+.spinner-box {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.loader {
+    width: 48px;
+    height: 48px;
+    border: 5px solid #FFF;
+    border-bottom-color: #3A5BA0;
+    border-radius: 50%;
+    display: inline-block;
+    box-sizing: border-box;
+    animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+} 

--- a/src/main/resources/static/css/portfolio/portfolio.css
+++ b/src/main/resources/static/css/portfolio/portfolio.css
@@ -11,6 +11,12 @@ main {
 }
 */
 
+main {
+    margin: 100px 0;
+    padding: 0 50px;
+    width: 100%;
+}
+
 .container {
     width: 100%; max-width: var(--max-content-width);
     margin: 0 auto;
@@ -473,34 +479,6 @@ main {
     font-weight: 500;
     font-size: 16px;
 }
-
-/* loading spinner */
-.spinner-box {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.loader {
-    width: 48px;
-    height: 48px;
-    border: 5px solid #FFF;
-    border-bottom-color: #3A5BA0;
-    border-radius: 50%;
-    display: inline-block;
-    box-sizing: border-box;
-    animation: rotation 1s linear infinite;
-}
-
-@keyframes rotation {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
-} 
 
 /* scroll error*/
 .scroll-error-box {

--- a/src/main/resources/static/css/portfolio/portfolio_detail.css
+++ b/src/main/resources/static/css/portfolio/portfolio_detail.css
@@ -11,6 +11,12 @@ main {
 }
 */
 
+main {
+    margin: 100px 0;
+    padding: 0 50px;
+    width: 100%;
+}
+
 .container {
     width: 100%; max-width: var(--max-content-width);
     margin: 0 auto;

--- a/src/main/resources/static/css/portfolio/portfolio_write.css
+++ b/src/main/resources/static/css/portfolio/portfolio_write.css
@@ -11,6 +11,13 @@ main {
 }
 */
 
+main {
+    margin: 100px 0;
+    padding: 0 50px;
+    width: 100%;
+    position: relative;
+}
+
 .container {
     width: 100%; max-width: var(--max-content-width);
     margin: 0 auto;
@@ -401,6 +408,53 @@ main {
     display: inline-block;
     font-size: 14px;
     color: #2F2F2F;
+}
+
+#template-ai {
+    border-radius: var(--box-radius-10);
+    padding: 3px 5px;
+    border:none;
+    background-color:#3A5BA0;
+    color: white;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    scale: 1;
+}
+
+#template-ai:hover {
+    opacity: 0.8;
+}
+
+#template-ai:disabled {
+    cursor: not-allowed;
+    background-color: #B1B1B1;
+    color: black;
+}
+
+/* loading overlay */
+#loading-overlay {
+    width: 100%; height: 100%;
+    display: none;
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 9999;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    font-size: 24px;
+}
+
+#loading-overlay.active {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+#loading-overlay .spinner-box {
+    gap: 20px;
 }
 
 /* 수정 페이지에만 적용 */

--- a/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
+++ b/src/main/resources/static/js/portfolio/portfolio-write-ckeditor5.js
@@ -24,6 +24,9 @@ function initializeEditor() {
         });
 }
 
+/**
+ * CKEditor에 이미지 업로드 후 input 추가
+ */
 function addImageInfoInput(editor) {
     // 이미지 업로드 후 input 추가
     const imageUploadEditing = editor.plugins.get('ImageUploadEditing');
@@ -42,12 +45,16 @@ function addImageInfoInput(editor) {
     });
 }
 
+/**
+ * CKEditor에 등록한 이미지 제거 시 input 제거
+ */
 function manageImageInfoInput(editor) {
     const model = editor.model;
     model.document.registerPostFixer(writer => {
         const changes = model.document.differ.getChanges();
         let handled = false;
 
+        // CKEditor 내의 이벤트 감지
         for (const change of changes) {
             if ((change.name === 'imageBlock' || change.name === 'imageInline')) {
                 if (change.type === 'remove') {

--- a/src/main/resources/static/prompts/portfolio_template.txt
+++ b/src/main/resources/static/prompts/portfolio_template.txt
@@ -1,1 +1,1 @@
-개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading(heading2 ~ heading4내에서)도 함께 추천해줘. 그리고 그 결과를 key=tagType과 value=value라는 쌍으로 된 structured output의 JSON 형식으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.
+개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. [%s] 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading(heading2 ~ heading4내에서)도 함께 추천해줘. 그리고 그 결과를 key=tagType과 value=value라는 쌍으로 된 structured output의 JSON 형식으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.

--- a/src/main/resources/static/prompts/portfolio_template.txt
+++ b/src/main/resources/static/prompts/portfolio_template.txt
@@ -1,1 +1,1 @@
-개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading(2부터 4)도 함께 추천해줘. 그리고 그 결과를 JSON 형식의 key=tagType과 value=value라는 쌍으로 된 structured output으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.
+개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading을 2번부터 4번까지 내에서도 함께 추천해줘. 그리고 그 결과를 JSON 형식의 key=tagType과 value=value라는 쌍으로 된 structured output으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.

--- a/src/main/resources/static/prompts/portfolio_template.txt
+++ b/src/main/resources/static/prompts/portfolio_template.txt
@@ -1,1 +1,1 @@
-개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading을 2번부터 4번까지 내에서도 함께 추천해줘. 그리고 그 결과를 JSON 형식의 key=tagType과 value=value라는 쌍으로 된 structured output으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.
+개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading(heading2 ~ heading4내에서)도 함께 추천해줘. 그리고 그 결과를 key=tagType과 value=value라는 쌍으로 된 structured output의 JSON 형식으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.

--- a/src/main/resources/static/prompts/portfolio_template.txt
+++ b/src/main/resources/static/prompts/portfolio_template.txt
@@ -1,0 +1,1 @@
+개발자 프로젝트에 대한 포트폴리오를 작성하고 있어. %s 프로젝트를 진행했을 때 자주 사용하는 목차를 추천하고, 각 목차에 걸맞는 HTML의 heading(2부터 4)도 함께 추천해줘. 그리고 그 결과를 JSON 형식의 key=tagType과 value=value라는 쌍으로 된 structured output으로만 출력해줘. tagType에는 heading을 작성하고, 목차 내용에는 value를 작성해줘.

--- a/src/main/resources/templates/portfolio/portfolio_edit.html
+++ b/src/main/resources/templates/portfolio/portfolio_edit.html
@@ -163,7 +163,7 @@
                     </li>
                     <li>
                         <div class="radio-input-group">
-                            <input type="radio" id="template-ai" name="template">
+                            <input type="button" id="template-ai" value="추천받기">
                             <label>AI 추천 템플릿</label>
                         </div>
                         <span>Alan AI가 추천하는 포트폴리오 템플릿</span>
@@ -171,6 +171,12 @@
                 </ul>
             </div>
         </aside>
+    </div>
+    <div id="loading-overlay">
+        <div class="spinner-box">
+            <div class="loader"></div>
+            <span>요청 처리중...</span>
+        </div>
     </div>
 </main>
 <footer></footer>

--- a/src/main/resources/templates/portfolio/portfolio_write.html
+++ b/src/main/resources/templates/portfolio/portfolio_write.html
@@ -141,7 +141,7 @@
                     </li>
                     <li>
                         <div class="radio-input-group">
-                            <input type="radio" id="template-ai" name="template">
+                            <input type="button" id="template-ai" value="추천받기">
                             <label>AI 추천 템플릿</label>
                         </div>
                         <span>Alan AI가 추천하는 포트폴리오 템플릿</span>
@@ -149,6 +149,12 @@
                 </ul>
             </div>
         </aside>
+    </div>
+    <div id="loading-overlay">
+        <div class="spinner-box">
+            <div class="loader"></div>
+            <span>요청 처리중...</span>
+        </div>
     </div>
 </main>
 <footer></footer>


### PR DESCRIPTION
## ✍️ 변경 요약 (Summary of Changes)
- Alan AI 요청 관련 클래스 추가
- Alan AI에 포트폴리오 템플릿 요청 API 추가
- 포트폴리오 작성과 수정 페이지에 AI 템플릿 추천 기능 추가
- 포트폴리오 조회수와 좋아요 카운트 변경

## 🧠 변경 이유 (Motivation / Why)
- Alan AI를 적용한 AI 서비스 도입으로 다양한 포트폴리오 템플릿을 제공
- 연관된 이슈 : #21, #49

## ✅ 리뷰어가 확인해야 할 사항 (Review Guidance)
- RestClient 등록과 RestTemplate 구조의 적합성
- AIService 구조의 적합성
- JavaDoc 누락 여부
- 클라이언트에서 API 요청 응답 대기 중에 중복 응답 요청이 잘 차단되어 있는지
- `application-develop.yml`과 `application-production.yml`의 변경 사항(`.env` 파일 업데이트 필요)

## 📎 관련 링크
- https://rudaks.tistory.com/entry/%EC%8A%A4%ED%94%84%EB%A7%81%EB%B6%80%ED%8A%B8-gemini-api-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0
- https://learngoeson.tistory.com/29#3.%20RestTemplate-1
- https://ai.google.dev/gemini-api/docs/structured-output#javascript
- https://adjh54.tistory.com/233#3)%20WebClient%20%EC%9D%B4%EC%9A%A9%EB%B0%A9%EB%B2%95%20%3A%20%EC%A3%BC%EC%9A%94%20%EB%A9%94%EC%84%9C%EB%93%9C-1-11
- https://bamdal.tistory.com/entry/Spring-Boot-Webflux%EA%B0%80-%EB%AD%98%EA%B9%8C
- https://docs.spring.io/spring-framework/reference/integration/rest-clients.html
- https://yeomylaoo.tistory.com/883
- https://www.javacodegeeks.com/http-delete-with-request-body.html
- https://stackoverflow.com/questions/78084176/how-to-set-connect-read-timeout-in-the-springs-restclient