### PR TITLE
feat(community): 커뮤니티 검색 서버 동작 2차 추가, 클라이언트 동작 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.3</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
@@ -28,7 +28,7 @@ public class CommunitySearchRequestDto {
      */
     @Min(value = 1, message = "페이지 최소 크기는 1 이상이어야 합니다.")
     @Max(value = 100, message = "페이지 최대 크기는 100 이하여야 합니다.")
-    private int size = 20;
+    private int size = 10;
 
     /**
      * 검색 키워드
@@ -46,7 +46,7 @@ public class CommunitySearchRequestDto {
     /**
      * 정렬 기준
      */
-    private CommunitySort sort = CommunitySort.UPDATED_AT;
+    private CommunitySort sort = CommunitySort.CREATED_AT;
 
     /**
      * 정렬 방향

--- a/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
@@ -46,7 +46,7 @@ public class CommunitySearchRequestDto {
     /**
      * 정렬 기준
      */
-    private CommunitySort sort = CommunitySort.CREATED_AT;
+    private CommunitySort sort = CommunitySort.UPDATED_AT;
 
     /**
      * 정렬 방향

--- a/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/community/CommunitySearchRequestDto.java
@@ -56,6 +56,6 @@ public class CommunitySearchRequestDto {
     @AssertTrue(message = "유효하지 않은 정렬 기준입니다.")
     public boolean isValidSort() {
         if (sort == null) return true;
-        return CommunitySort.fromFieldName(sort.getFieldName()) != null;
+        return CommunitySort.fromName(sort.name()) != null;
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/community/PostListResponseDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/community/PostListResponseDto.java
@@ -30,7 +30,7 @@ public class PostListResponseDto {
      * @param post 변환할 CommunityPost 엔티티
      * @return 변환된 PostListResponse 객체
      */
-    public static PostListResponseDto from(CommunityPost post, long commentCount) {
+    public static PostListResponseDto from(CommunityPost post) {
         return new PostListResponseDto(
                 post.getPostIdx(),
                 post.getTitle(),
@@ -42,7 +42,7 @@ public class PostListResponseDto {
                 post.getStatus(),
                 post.getContent(),
                 post.getUser().getProfileImg(),
-                commentCount
+                post.getCommentCount()
         );
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioPageRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioPageRequestDto.java
@@ -44,6 +44,6 @@ public class PortfolioPageRequestDto {
     @AssertTrue(message = "유효하지 않은 정렬 기준입니다.")
     public boolean isValidSort() {
         if (sort == null) return true;
-        return PortfolioSort.fromFieldName(sort.getFieldName()) != null;
+        return PortfolioSort.fromName(sort.name()) != null;
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioSearchRequestDto.java
+++ b/src/main/java/io/github/sunday/devfolio/DTO/portfolio/PortfolioSearchRequestDto.java
@@ -59,6 +59,6 @@ public class PortfolioSearchRequestDto {
     @AssertTrue(message = "유효하지 않은 정렬 기준입니다.")
     public boolean isValidSort() {
         if (sort == null) return true;
-        return PortfolioSort.fromFieldName(sort.getFieldName()) != null;
+        return PortfolioSort.fromName(sort.name()) != null;
     }
 }

--- a/src/main/java/io/github/sunday/devfolio/controller/community/CommunityController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/community/CommunityController.java
@@ -4,7 +4,6 @@ import io.github.sunday.devfolio.config.CustomUserDetails;
 import io.github.sunday.devfolio.dto.community.*;
 import io.github.sunday.devfolio.entity.table.community.Category;
 import io.github.sunday.devfolio.enums.CommunitySort;
-import io.github.sunday.devfolio.enums.PortfolioSort;
 import io.github.sunday.devfolio.service.community.CommunityService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -50,12 +49,13 @@ public class CommunityController {
         });
 
         // sort 유효성 검증
-        binder.registerCustomEditor(PortfolioSort.class, new PropertyEditorSupport() {
+        binder.registerCustomEditor(CommunitySort.class, new PropertyEditorSupport() {
             @Override
             public void setAsText(String text) throws IllegalArgumentException {
-                PortfolioSort sort = PortfolioSort.fromFieldName(text);
+                CommunitySort sort = CommunitySort.fromName(text);
+                System.out.println(sort.name());
                 if (sort == null) {
-                    sort = PortfolioSort.UPDATED_AT;
+                    sort = CommunitySort.UPDATED_AT;
                 }
                 setValue(sort);
             }
@@ -87,6 +87,7 @@ public class CommunityController {
     public String listPosts(@Valid @ModelAttribute("searchRequestDto") CommunitySearchRequestDto requestDto,
                             Model model) {
         Page<PostListResponseDto> postPage = communityService.getPosts(requestDto);
+        System.out.println(requestDto.getSize());
         model.addAttribute("postPage", postPage);
         model.addAttribute("requestDto", requestDto);
         model.addAttribute("categories", Category.values());

--- a/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioController.java
@@ -56,7 +56,7 @@ public class PortfolioController {
         binder.registerCustomEditor(PortfolioSort.class, new PropertyEditorSupport() {
             @Override
             public void setAsText(String text) throws IllegalArgumentException {
-                PortfolioSort sort = PortfolioSort.fromFieldName(text);
+                PortfolioSort sort = PortfolioSort.fromName(text);
                 if (sort == null) {
                     sort = PortfolioSort.UPDATED_AT;
                 }

--- a/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioRestController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioRestController.java
@@ -55,7 +55,7 @@ public class PortfolioRestController {
         binder.registerCustomEditor(PortfolioSort.class, new PropertyEditorSupport() {
             @Override
             public void setAsText(String text) throws IllegalArgumentException {
-                PortfolioSort sort = PortfolioSort.fromFieldName(text);
+                PortfolioSort sort = PortfolioSort.fromName(text);
                 if (sort == null) {
                     sort = PortfolioSort.UPDATED_AT;
                 }

--- a/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioRestController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/portfolio/PortfolioRestController.java
@@ -83,7 +83,6 @@ public class PortfolioRestController {
         return ResponseEntity.ok().body(list);
     }
 
-
     /**
      * 포트폴리오 제거
      */

--- a/src/main/java/io/github/sunday/devfolio/entity/table/community/Category.java
+++ b/src/main/java/io/github/sunday/devfolio/entity/table/community/Category.java
@@ -1,5 +1,8 @@
 package io.github.sunday.devfolio.entity.table.community;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * 커뮤니티 게시글의 카테고리를 정의한 열거형입니다.
  * <ul>
@@ -8,13 +11,17 @@ package io.github.sunday.devfolio.entity.table.community;
  *   <li>general</li>
  * </ul>
  */
+@Getter
+@RequiredArgsConstructor
 public enum Category {
-    study,
-    question,
-    general;
+    study("스터디 그룹 모집"),
+    question("질문 & 답변"),
+    general("자유 게시판");
+
+    private final String nameKo;
 
     public static boolean isValid(String value) {
-        if (value == null) return false;
+        if (value == null) return true;
         return java.util.Arrays.stream(Category.values())
                 .anyMatch(c -> c.name().equals(value));
     }

--- a/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
+++ b/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
@@ -23,9 +23,9 @@ public enum CommunitySort {
     /**
      * 필드 이름으로 CommunitySort 탐색
      */
-    public static CommunitySort fromFieldName(String fieldName) {
+    public static CommunitySort fromName(String name) {
         for (CommunitySort sort : values()) {
-            if (sort.getFieldName().equalsIgnoreCase(fieldName))
+            if (sort.name().equalsIgnoreCase(name))
                 return sort;
         }
         return null;

--- a/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
+++ b/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
@@ -12,7 +12,7 @@ public enum CommunitySort {
     /**
      * 수정 날짜, 댓글 수, 조회수, 좋아요 수
      */
-    UPDATED_AT("updatedAt", "최신순"),
+    CREATED_AT("createdAt", "최신순"),
     COMMENT_COUNT("commentCount", "댓글수"),
     VIEWS("views", "조회수"),
     LIKE_COUNT("likeCount", "좋아요수");

--- a/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
+++ b/src/main/java/io/github/sunday/devfolio/enums/CommunitySort.java
@@ -12,7 +12,7 @@ public enum CommunitySort {
     /**
      * 수정 날짜, 댓글 수, 조회수, 좋아요 수
      */
-    CREATED_AT("createdAt", "최신순"),
+    UPDATED_AT("updatedAt", "최신순"),
     COMMENT_COUNT("commentCount", "댓글수"),
     VIEWS("views", "조회수"),
     LIKE_COUNT("likeCount", "좋아요수");

--- a/src/main/java/io/github/sunday/devfolio/enums/PortfolioSort.java
+++ b/src/main/java/io/github/sunday/devfolio/enums/PortfolioSort.java
@@ -23,9 +23,9 @@ public enum PortfolioSort {
     /**
      * 필드 이름으로 PortfolioSort 탐색
      */
-    public static PortfolioSort fromFieldName(String fieldName) {
+    public static PortfolioSort fromName(String name) {
         for (PortfolioSort sort : values()) {
-            if (sort.getFieldName().equalsIgnoreCase(fieldName))
+            if (sort.name().equalsIgnoreCase(name))
                 return sort;
         }
         return null;

--- a/src/main/java/io/github/sunday/devfolio/repository/community/CommunityQueryDslRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/community/CommunityQueryDslRepository.java
@@ -121,7 +121,6 @@ public class CommunityQueryDslRepository {
 
                     // 정렬 기준 필드명
                     String property = order.getProperty();
-
                     return new OrderSpecifier(direction, pathBuilder.get(property));
                 })
                 .orElse(null);

--- a/src/main/java/io/github/sunday/devfolio/service/community/CommunityService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/community/CommunityService.java
@@ -40,7 +40,9 @@ public class CommunityService {
      * @return 페이징 처리된 게시글 목록 (PostListResponse)
      */
 
-    public Page<PostListResponseDto> getPosts(Pageable pageable) {
+    public Page<PostListResponseDto> getPosts(CommunitySearchRequestDto requestDto) {
+        Sort sort = Sort.by(requestDto.getDirection(), requestDto.getSort().getFieldName());
+        Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getSize(), sort);
         return communityPostRepository.findPostsWithCommentCount(pageable);
     }
 
@@ -54,7 +56,7 @@ public class CommunityService {
         Pageable pageable = PageRequest.of(searchRequestDto.getPage(), searchRequestDto.getSize(), sort);
         List<CommunityPost> postList = communityQueryDslRepository.findAllByKeywordAndCategory(searchRequestDto, pageable);
         List<PostListResponseDto> list = postList.stream()
-                .map(post -> PostListResponseDto.from(post, 0))
+                .map(post -> PostListResponseDto.from(post))
                 .toList();
         return new PageImpl<>(list, pageable, list.size());
     }

--- a/src/main/java/io/github/sunday/devfolio/validator/community/CommunityCategoryValidator.java
+++ b/src/main/java/io/github/sunday/devfolio/validator/community/CommunityCategoryValidator.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class CommunityCategoryValidator implements ConstraintValidator<CommunityCategoryValid, String> {
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        if (value == null) return false;
+        if (value == null) return true;
         return Category.isValid(value);
     }
 }

--- a/src/main/resources/static/css/community/community_list.css
+++ b/src/main/resources/static/css/community/community_list.css
@@ -100,7 +100,7 @@
     align-items: center;
     margin-bottom: 1.5rem;
 }
-.sort-tabs a {
+.sort-tabs button {
     color: #868e96;
     background-color: #f1f3f5;
     text-decoration: none;
@@ -109,8 +109,10 @@
     font-weight: 500;
     margin-right: 0.5rem;
     font-size: 0.9rem;
+    border: none;
+    cursor: pointer;
 }
-.sort-tabs a.active {
+.sort-tabs button.active {
     background-color: #339af0;
     color: white;
     font-weight: 700;

--- a/src/main/resources/static/js/community/community-list.js
+++ b/src/main/resources/static/js/community/community-list.js
@@ -1,0 +1,51 @@
+const url = new URL(window.location.href);
+const params = new URLSearchParams(window.location.search);
+
+/**
+ * 카테고리 탭 스타일 지정
+ */
+function setCategoryTabStyle() {
+    const categorySidebar = document.querySelector(".category-sidebar");
+    const categoryTabs = categorySidebar.querySelectorAll("li a");
+    if (params.get("categoryName") === null) {
+        categoryTabs[0].classList.add("active");
+    } else {
+        categoryTabs.forEach((tab) => {
+            const category = tab.dataset.category;
+            if (category === params.get("categoryName")) {
+                tab.classList.add("active");
+            }
+        });
+    }
+}
+
+/**
+ * 정렬 버튼 이벤트 리스너
+ */
+function addSortButtonAction() {
+    const sortTabs = document.querySelector(".sort-tabs");
+    const sortButtons = sortTabs.querySelectorAll("button");
+    sortButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+            const sort = button.dataset.sort;
+            const order = "DESC";
+
+            const params = new URLSearchParams(window.location.search);
+            const url = new URL(window.location);
+
+            params.set("sort", sort);
+            params.set("direction", order);
+
+            url.search = params.toString();
+            window.location.href = url.toString();
+        });
+    });
+}
+
+/**
+ * DOMContentLoaded 이벤트 리스너
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    setCategoryTabStyle();
+    addSortButtonAction();
+});

--- a/src/main/resources/static/js/portfolio/portfolio.js
+++ b/src/main/resources/static/js/portfolio/portfolio.js
@@ -42,7 +42,7 @@ function addSortButtonAction() {
       const url = new URL(window.location);
 
       params.set("sort", sort);
-      params.set("order", order);
+      params.set("direction", order);
 
       url.search = params.toString();
       window.location.href = url.toString();

--- a/src/main/resources/templates/community/community_list.html
+++ b/src/main/resources/templates/community/community_list.html
@@ -19,27 +19,42 @@
         <aside class="category-sidebar">
             <h2>커뮤니티 카테고리</h2>
             <ul>
-                <li><a href="#" class="active">스터디 그룹 모집</a></li>
-                <li><a href="#">질문 & 답변</a></li>
-                <li><a href="#">자유 게시판</a></li>
+                <li><a href="/community">전체</a></li>
+                <li th:each="category : ${categories}">
+                    <a th:href="${'/community/search?categoryName=' + category}"
+                       th:data-category="${category}"
+                       th:text="${category.nameKo}"></a>
+                </li>
             </ul>
         </aside>
 
         <section class="content-area">
             <!-- 1. 검색창 -->
-            <div class="search-bar">
-                <select name="category"><option value="all">카테고리</option></select>
-                <input type="text" placeholder="검색">
-                <button type="button" class="search-btn"><img th:src="@{/assets/icon/search.svg}" alt="검색 아이콘"/></button>
-            </div>
+            <form class="search-bar" th:action="@{/community/search}" method="get" id="search-form">
+                <select class="categories"
+                        th:field="${requestDto.categoryName}"
+                >
+                    <option value="">전체</option>
+                    <option
+                            th:each="category: ${categories}"
+                            th:value="${category}"
+                            th:text="${category.nameKo}"
+                    ></option>
+                </select>
+                <input type="text" name="keyword" placeholder="검색 키워드를 입력해주세요"
+                       th:value="${requestDto.keyword}">
+                <button type="submit" class="search-btn"><img th:src="@{/assets/icon/search.svg}" alt="검색 아이콘"/></button>
+            </form>
 
             <!-- 2. 정렬 탭과 글쓰기 버튼 -->
             <div class="actions-and-sort">
                 <div class="sort-tabs">
-                    <a href="#" class="active">최신순</a>
-                    <a href="#">댓글순</a>
-                    <a href="#">조회수순</a>
-                    <a href="#">좋아요순</a>
+                    <button type="button"
+                            th:each="sort : ${sortOptions}"
+                            th:data-sort="${sort}"
+                            th:classappend="${#strings.equals(requestDto.sort, sort) ? 'active' : ''}"
+                            th:text="${sort.fieldNameKo}"
+                    ></button>
                 </div>
                 <a th:href="@{/community/new}" class="btn-primary">새 게시글 작성</a>
             </div>
@@ -101,5 +116,6 @@
         </section>
     </main>
 </div>
+<script type="module" th:src="@{/js/community/community-list.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## ✍️ 변경 요약 (Summary of Changes)
- 커뮤니티 목록에 검색, 정렬, 필터링 상호작용 기능 추가
- 커뮤니티 정렬 기준을 수정 날짜 기준에서 생성 날짜 기준으로 변경
- build 시 JavaDoc을 제외하는 빌드 의존성 추가

## 🧠 변경 이유 (Motivation / Why)
- 사용자에게 검색과 필터링 기능을 제공
- Entity 설정 시 수정 날짜에 null 허용으로 인해 적용
- 연관된 이슈 : #51 

## ✅ 리뷰어가 확인해야 할 사항 (Review Guidance)
- CommunitySort의 정렬 기준 변경
- PortfolioListResponseDto 변경
- Controller의 listPosts() 메서드와 CommunityService의 getPosts() 메서드의 매개변수 변경
- community_list.html에서 상호작용을 위한 구조 변경 및 데이터 출력 변경
- community-list.js에 적용된 정렬 버튼 상호작용