### PR TITLE
chore : 이미지 의존성 변경 및 파일 용량 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
 			<type>pom</type>
 		</dependency>
 		<dependency>
+			<groupId>com.github.downgoon</groupId>
+			<artifactId>MarvinPlugins</artifactId>
+			<version>1.5.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>

--- a/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class SecureImageService {
 
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final long MAX_FILE_SIZE = 100 * 1024 * 1024; // 10MB
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
             "image/jpeg",
             "image/jpg",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: ${MAX_FILE_SIZE:5MB}
-      max-request-size: ${MAX_REQUEST_SIZE:5MB}
+      max-file-size: ${MAX_FILE_SIZE:100MB}
+      max-request-size: ${MAX_REQUEST_SIZE:100MB}
   thymeleaf:
     cache: false
     prefix: classpath:/templates/


### PR DESCRIPTION
## ✍️ 변경 요약 (Summary of Changes)
- 이미지 리사이즈 관련 의존성 추가(MarvinPlugins),
- 이미지 업로드 시 파일 용량을 100MB로 확장

## 🧠 변경 이유 (Motivation / Why)
- 중복된 의존성 제거 과정에서 원본 의존성이 제거됨
- 이미지 파일 업로드 시 용량을 더 크게 설정해서 큰 파일도 받을 수 있도록 수정
