### PR TITLE
feat: 소셜 회원의 경우 비밀번호 재확인 없이 프로필 수정 가능하게 변경

### DIFF
--- a/src/main/java/io/github/sunday/devfolio/dto/ProfileDto.java
+++ b/src/main/java/io/github/sunday/devfolio/dto/ProfileDto.java
@@ -1,5 +1,6 @@
 package io.github.sunday.devfolio.dto;
 
+import io.github.sunday.devfolio.entity.table.user.AuthProvider;
 import lombok.Builder;
 import lombok.Data;
 
@@ -18,6 +19,9 @@ public class ProfileDto {
 
     /** 이메일(표시/연락 목적) */
     private String email;
+
+    /** OAuth 제공자 */
+    private AuthProvider oauthProvider;
 
     /** 프로필 이미지 URL */
     private String profileImg;

--- a/src/main/java/io/github/sunday/devfolio/service/ProfileService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/ProfileService.java
@@ -61,6 +61,7 @@ public class ProfileService {
                 .userIdx(target.getUserIdx())
                 .nickname(target.getNickname())
                 .email(target.getEmail())
+                .oauthProvider(target.getOauthProvider())
                 .profileImg(target.getProfileImg())
                 .githubUrl(target.getGithubUrl())
                 .blogUrl(target.getBlogUrl())

--- a/src/main/resources/templates/profile/profile.html
+++ b/src/main/resources/templates/profile/profile.html
@@ -68,9 +68,16 @@
         <h1 class="text-2xl font-bold capitalize" th:text="${tab}">resume</h1>
 
         <div>
-            <button th:if="${isSelf}" class="px-4 py-2 bg-blue-600 text-white rounded"
+            <!-- 본인 프로필 & 로컬 회원일 경우 -->
+            <button th:if="${isSelf and user.oauthProvider.name() == 'LOCAL'}" class="px-4 py-2 bg-blue-600 text-white rounded"
                     type="button" onclick="openVerifyModal()">프로필 수정</button>
 
+            <!-- 본인 프로필 & 소셜 회원일 경우 -->
+            <a th:if="${isSelf and user.oauthProvider.name() != 'LOCAL'}"
+               th:href="@{|/profile/${user.userIdx}/edit|}"
+               class="px-4 py-2 bg-blue-600 text-white rounded inline-block">프로필 수정</a>
+
+            <!-- 타인 프로필일 경우 -->
             <form th:if="${!isSelf}" th:action="@{|/profile/${user.userIdx}/follow|}" method="post" class="inline">
                 <input type="hidden" name="ownerUserIdx" th:value="${user.userIdx}"/>
                 <input type="hidden" name="tab" th:value="${tab}"/>


### PR DESCRIPTION
> feat: 소셜 회원의 경우 비밀번호 재확인 없이 프로필 수정 가능하게 변경 [#56]


## ✍️ 변경 요약 (Summary of Changes)
- 셜 회원의 경우 비밀번호 재확인 없이 프로필 수정 가능하게 변경

## 🧠 변경 이유 (Motivation / Why)
- 소셜 회원의 경우 비밀번호가 없어서 비밀번호 재확인이 불가능


