### PR TITLE
feat: 소셜 회원의 경우 프로필 수정 시 이메일, 비밀번호 수정 불가능 하게 기능 구현

### DIFF
--- a/src/main/java/io/github/sunday/devfolio/controller/ProfileViewController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/ProfileViewController.java
@@ -185,6 +185,7 @@ public class ProfileViewController {
 
         model.addAttribute("form", form);
         model.addAttribute("userIdx", userIdx);
+        model.addAttribute("oauthProvider", currentUser.getOauthProvider());
         return "profile/profile_edit";
     }
 

--- a/src/main/java/io/github/sunday/devfolio/service/ProfileUpdateService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/ProfileUpdateService.java
@@ -2,6 +2,7 @@ package io.github.sunday.devfolio.service;
 
 
 import io.github.sunday.devfolio.dto.ProfileUpdateRequest;
+import io.github.sunday.devfolio.entity.table.user.AuthProvider;
 import io.github.sunday.devfolio.entity.table.user.EmailVerification;
 import io.github.sunday.devfolio.entity.table.user.User;
 import io.github.sunday.devfolio.repository.EmailVerificationRepository;
@@ -32,6 +33,12 @@ public class ProfileUpdateService {
 
     @Transactional
     public User updateProfile(User currentUser, ProfileUpdateRequest req) {
+        if (currentUser.getOauthProvider() != AuthProvider.LOCAL) {
+            // 소셜 회원이면 이메일/비밀번호 무시
+            req.setEmail(currentUser.getEmail());
+            req.setPassword(null);
+        }
+
         String email = req.getEmail().trim().toLowerCase();
         String nickname = req.getNickname().trim();
         String password = req.getPassword();
@@ -91,4 +98,3 @@ public class ProfileUpdateService {
         return userRepository.existsByNicknameAndUserIdxNot(nickname, userIdx);
     }
 }
-

--- a/src/main/resources/templates/profile/profile_edit.html
+++ b/src/main/resources/templates/profile/profile_edit.html
@@ -31,12 +31,15 @@
                     <div id="nickname-msg" class="msg"></div>
                 </label>
 
-                <label>이메일
+                <label th:if="${oauthProvider == T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">이메일
                     <div class="flex">
                         <input type="email" id="email" th:field="*{email}" class="border rounded w-full px-3 py-2"/>
                         <button type="button" id="emailSend" class="check-btn" onclick="sendCode(event)">인증코드 발송</button>
                     </div>
                     <div id="email-msg" class="msg"></div>
+                </label>
+                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">이메일 수정 불가
+                    <input type="hidden" th:field="*{email}" />
                 </label>
 
                 <!-- 인증코드 입력 -->
@@ -48,8 +51,11 @@
                     <div id="email-verify-msg" class="msg"></div>
                 </div>
 
-                <label>새 비밀번호 (선택)
+                <label th:if="${oauthProvider == T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">새 비밀번호 (선택)
                     <input type="password" th:field="*{password}" class="border rounded w-full px-3 py-2"/>
+                </label>
+                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">비밀번호 수정 불가
+                    <input type="hidden" th:field="*{password}" />
                 </label>
 
                 <label>Github URL


### PR DESCRIPTION
> feat: 소셜 회원의 경우 프로필 수정 시 이메일, 비밀번호 수정 불가능 하게 기능 구현 [#56]


## ✍️ 변경 요약 (Summary of Changes)
- 로컬 회원의 경우 그대로, 소셜 회원의 경우 이메일, 닉네임 수정 불가

## 🧠 변경 이유 (Motivation / Why)
- 소셜 회원의 경우 이메일은 고정되어야 하고, 비밀번호는 없으므로 수정 못하게 막음

