### PR TITLE
style/profile

### DIFF
--- a/src/main/java/io/github/sunday/devfolio/controller/ProfileViewController.java
+++ b/src/main/java/io/github/sunday/devfolio/controller/ProfileViewController.java
@@ -202,6 +202,7 @@ public class ProfileViewController {
             updateService.updateProfile(currentUser, form);
             return "redirect:/profile/" + userIdx + "?tab=resume";
         } catch (IllegalArgumentException e) {
+            model.addAttribute("oauthProvider", currentUser.getOauthProvider());
             model.addAttribute("form", form);
             model.addAttribute("userIdx", userIdx);
             model.addAttribute("error", e.getMessage());

--- a/src/main/resources/static/css/profilepage/profile.css
+++ b/src/main/resources/static/css/profilepage/profile.css
@@ -20,6 +20,7 @@
 html, body { height: 100%; }
 body{
   margin: 0;
+  padding-top: 60px;
   color: var(--text);
   background: var(--bg);
   font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans KR", Arial, sans-serif;
@@ -62,6 +63,7 @@ a:hover{ text-decoration: underline; }
 .mt-6{ margin-top: 1.5rem; }
 .mr-4{ margin-right: 1rem; }
 .mb-2{ margin-bottom: .5rem; }
+.mb-4{ margin-bottom: 1rem; }
 
 .space-y-1 > * + *{ margin-top: .25rem; }
 .space-y-6 > * + *{ margin-top: 1.5rem; }

--- a/src/main/resources/static/css/profilepage/profile.css
+++ b/src/main/resources/static/css/profilepage/profile.css
@@ -70,7 +70,7 @@ a:hover{ text-decoration: underline; }
 
 .bg-white{ background: var(--card); }
 .bg-gray-100{ background: var(--bg); }
-.bg-blue-600{ background: var(--primary); }
+.bg-blue-600{ background: #3A5BA0; }
 .bg-blue-100{ background: var(--primary-100); }
 
 .text-white{ color: #fff; }
@@ -164,13 +164,13 @@ h1.text-2xl{
   padding:.5rem 1rem; border-radius: var(--radius); border:1px solid var(--border);
   background:#fff; color: var(--text);
 }
-.btn--primary{ background: var(--primary); color:#fff; border-color: transparent; }
+.btn--primary{ background: #3A5BA0; color:#fff; border-color: transparent; }
 .btn--muted{ background:#f3f4f6; }
 .btn:hover{ filter: brightness(0.98); }
 
 .check-btn{
 padding: 0.5rem 1rem;
-    background-color: var(--primary);
+    background-color: #3A5BA0;
     color: white;
     border-radius: 0.5rem;
     border: none;

--- a/src/main/resources/templates/profile/profile.html
+++ b/src/main/resources/templates/profile/profile.html
@@ -19,6 +19,7 @@
     </script>
 </head>
 <body class="min-h-screen bg-gray-100 flex">
+<header th:replace="~{fragments/header :: header}"></header>
 
 <!-- 사이드바 -->
 <aside class="w-64 bg-white p-6 space-y-6 shadow">

--- a/src/main/resources/templates/profile/profile_edit.html
+++ b/src/main/resources/templates/profile/profile_edit.html
@@ -14,16 +14,20 @@
     </script>
 </head>
 <body class="min-h-screen bg-gray-100">
+<header th:replace="~{fragments/header :: header}"></header>
+
 <main class="max-w-3xl mx-auto p-8">
     <section class="bg-white p-6 rounded shadow">
-        <h1 class="text-2xl font-bold mb-4">프로필 수정</h1>
+        <h1 class="text-2xl font-bold mb-6">프로필 수정</h1>
 
-        <div th:if="${error}" class="text-red-600 mb-3" th:text="${error}">에러 메시지</div>
+        <div th:if="${error}" class="text-red-600 mb-4" th:text="${error}">에러 메시지</div>
 
         <form th:action="@{|/profile/${userIdx}/edit|}" method="post" th:object="${form}">
             <div class="grid grid-cols-2 gap-4">
                 <label>프로필 이미지 URL
-                    <input type="text" th:field="*{profileImg}" class="border rounded w-full px-3 py-2"/>
+                    <div class="flex">
+                        <input type="text" th:field="*{profileImg}" class="border rounded w-full px-3 py-2"/>
+                    </div>
                 </label>
 
                 <label>닉네임
@@ -41,46 +45,56 @@
                     </div>
                     <div id="email-msg" class="msg"></div>
                 </label>
-                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">이메일 수정 불가
-                    <input type="hidden" th:field="*{email}" />
+                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}" class="mb-4">이메일 수정 불가
+                    <input type="hidden" th:field="*{email}"/>
                 </label>
 
                 <!-- 인증코드 입력 -->
-                <div id="email-code-section" class="mt-2" style="display:none;">
-                    <div class="flex">
-                        <input type="text" id="emailCode" placeholder="6자리 인증 코드 입력" class="border rounded w-full px-3 py-2"/>
-                        <button type="button" id="verify" class="check-btn" onclick="verifyCode(event)">인증 확인</button>
+                <label id="email-code-section" style="display:none;">인증 코드
+                    <div class="mt-2">
+                        <div class="flex">
+                            <input type="text" id="emailCode" placeholder="6자리 인증 코드 입력" class="border rounded w-full px-3 py-2"/>
+                            <button type="button" id="verify" class="check-btn" onclick="verifyCode(event)">인증 확인</button>
+                        </div>
+                        <div id="email-verify-msg" class="msg"></div>
                     </div>
-                    <div id="email-verify-msg" class="msg"></div>
-                </div>
+                </label>
 
                 <label th:if="${oauthProvider == T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">새 비밀번호 (선택)
-                    <input type="password" th:field="*{password}" class="border rounded w-full px-3 py-2"/>
+                    <div class="flex">
+                        <input type="password" th:field="*{password}" class="border rounded w-full px-3 py-2"/>
+                    </div>
                 </label>
-                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}">비밀번호 수정 불가
-                    <input type="hidden" th:field="*{password}" />
+                <label th:if="${oauthProvider != T(io.github.sunday.devfolio.entity.table.user.AuthProvider).LOCAL}" class="mb-4">비밀번호 수정 불가
+                    <input type="hidden" th:field="*{password}"/>
                 </label>
 
                 <label>Github URL
-                    <input type="text" th:field="*{githubUrl}" class="border rounded w-full px-3 py-2"/>
+                    <div class="flex">
+                        <input type="text" th:field="*{githubUrl}" class="border rounded w-full px-3 py-2"/>
+                    </div>
                 </label>
 
                 <label>블로그 URL
-                    <input type="text" th:field="*{blogUrl}" class="border rounded w-full px-3 py-2"/>
+                    <div class="flex">
+                        <input type="text" th:field="*{blogUrl}" class="border rounded w-full px-3 py-2"/>
+                    </div>
                 </label>
 
                 <label class="col-span-2">회사/학교 정보
-                    <input type="text" th:field="*{affiliation}" class="border rounded w-full px-3 py-2"/>
+                    <div class="flex">
+                        <input type="text" th:field="*{affiliation}" class="border rounded w-full px-3 py-2"/>
+                    </div>
                 </label>
             </div>
 
-            <div class="mt-6 flex justify-end gap-2">
+            <div class="mt-6 flex justify-end gap-2 mb-4">
                 <a th:href="@{|/profile/${userIdx}?tab=resume|}" class="btn">취소</a>
                 <button type="submit" class="btn btn--primary">수정하기</button>
             </div>
         </form>
 
-        <hr class="my-6"/>
+        <hr class="mb-4"/>
 
         <!-- 이력서 수정은 프로젝트 별 에디터/업로드 화면으로 이동하도록 링크만 제공 -->
         <div>


### PR DESCRIPTION
> style: 프로필, 프로필 수정 페이지 스타일 수정, 로컬 회원이 프로필 수정 시 시존 소셜 회원이 사용 중인 이메일 입력하면 이메일과 비밀번호 수정이 막히는 문제 해결 [#60]


## ✍️ 변경 요약 (Summary of Changes)
- 프로필, 프로필 수정 페이지 스타일 수정
- 프로필, 프로필 수정 페이지, 비밀번호 재확인 모달의 버튼 색상을 사이트 기본 색상과 통일
- 로컬 회원이 프로필 수정 시 시존 소셜 회원이 사용 중인 이메일 입력하고 수정 시도 시 수정 실패 후 이메일과 비밀번호 수정이 막히는 문제 해결

## 🧠 변경 이유 (Motivation / Why)
- 스타일 통일

