### PR TITLE
feat: 1분마다 만료기간이 지난 이메일 인증 정보 삭제

### DIFF
--- a/src/main/java/io/github/sunday/devfolio/config/SchedulerConfig.java
+++ b/src/main/java/io/github/sunday/devfolio/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package io.github.sunday.devfolio.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/io/github/sunday/devfolio/repository/EmailVerificationRepository.java
+++ b/src/main/java/io/github/sunday/devfolio/repository/EmailVerificationRepository.java
@@ -3,8 +3,11 @@ package io.github.sunday.devfolio.repository;
 import io.github.sunday.devfolio.entity.table.user.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findTopByEmailOrderByExpiredAtDesc(String email);
+
+    void deleteByExpiredAtBefore(ZonedDateTime now);
 }

--- a/src/main/java/io/github/sunday/devfolio/scheduler/EmailVerificationCleanupTask.java
+++ b/src/main/java/io/github/sunday/devfolio/scheduler/EmailVerificationCleanupTask.java
@@ -1,0 +1,23 @@
+package io.github.sunday.devfolio.scheduler;
+
+import io.github.sunday.devfolio.repository.EmailVerificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationCleanupTask {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    // 1분마다 실행
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void cleanup() {
+        emailVerificationRepository.deleteByExpiredAtBefore(ZonedDateTime.now());
+    }
+}


### PR DESCRIPTION
> feat: 1분마다 만료기간이 지난 이메일 인증 정보 삭제


## ✍️ 변경 요약 (Summary of Changes)
- 스케줄러를 등록해서 1분마다 만료기간이 지난 이메일 인증 정보 삭제

## 🧠 변경 이유 (Motivation / Why)
- 이메일 인증을 완료해도 인증 정보가 사라지지 않아 한 번이라도 인증이 완료된 이메일로 회원가입이나 프로필 수정을 할 때 인증번호를 발급받지 않고도 인증이 됐음.


