### PR TITLE
refactor : 이미지 유효성 체크에서 이미지 용량 한도 수정

### DIFF
--- a/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
+++ b/src/main/java/io/github/sunday/devfolio/service/common/SecureImageService.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class SecureImageService {
 
-    private static final long MAX_FILE_SIZE = 100 * 1024 * 1024; // 10MB
+    private static final long MAX_FILE_SIZE = 1000 * 1024 * 1024; // 100MB
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
             "image/jpeg",
             "image/jpg",
@@ -96,7 +96,7 @@ public class SecureImageService {
 
         // 파일 크기 검증
         if (file.getSize() > MAX_FILE_SIZE) {
-            throw new ImageValidationException("파일 크기는 10MB 이하여야 합니다.");
+            throw new ImageValidationException("파일 크기는 100MB 이하여야 합니다.");
         }
 
         // 파일 확장자 검증


### PR DESCRIPTION
## ✍️ 변경 요약 (Summary of Changes)
- 이미지 업로드 유효성 검사에서 이미지 용량 제한을 10MB에서 100MB로 변경

## 🧠 변경 이유 (Motivation / Why)
- 큰 용량의 이미지 파일 업로드 지원