### PR TITLE
fix: 프로필 페이지 게시글 링크 수정

### DIFF
--- a/src/main/resources/templates/profile/profile.html
+++ b/src/main/resources/templates/profile/profile.html
@@ -148,7 +148,7 @@
             <div th:each="p : ${posts}" class="border-b py-4 flex items-center justify-between">
                 <div class="mr-4">
                     <h3 class="font-semibold">
-                        <a th:text="${p.title}" th:href="@{|/posts/${p.postIdx}|}">게시글 제목</a>
+                        <a th:text="${p.title}" th:href="@{|/community/${p.postIdx}|}">게시글 제목</a>
                     </h3>
                     <p class="text-sm text-gray-500" th:text="${#temporals.format(p.createdAt, 'yyyy-MM-dd HH:mm')}">작성일</p>
                 </div>


### PR DESCRIPTION
> fix: 프로필 페이지 게시글 경로 수정


## ✍️ 변경 요약 (Summary of Changes)
- @{|/posts/${p.postIdx}|}에서@{|/community/${p.postIdx}|}로 경로 변경 

## 🧠 변경 이유 (Motivation / Why)
- 잘못된 링크로 되어 있었음


